### PR TITLE
Add throttle to prevent API credit exhaustion

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,14 @@ Air conditioning is exposed as climate.
 ### Device Tracker
 
 Location of vehicles are exposed as device trackers.
+
+## Sending updates
+
+To make sure updates end up in the car the way intended by the you, we throttle all equal changes to the car for 30s.
+Simply put: You can change a setting in the car once every 30s, but you can change multiple settings in sequence.
+
+So:
+- If you change the seat-heating to on, you can immediately change the window-heating to on as well.
+- If you change the seat-heating to on, you cannot turn it back off again for 30s
+
+The requests will silently be ignored by HomeAssistant, so make sure you wait at least 30s before sending another request

--- a/custom_components/myskoda/climate.py
+++ b/custom_components/myskoda/climate.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from datetime import timedelta
 from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityDescription,
@@ -14,10 +15,11 @@ from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
+from homeassistant.util import Throttle
 from myskoda.models.air_conditioning import AirConditioning
 from myskoda.models.info import CapabilityId
 
-from .const import COORDINATORS, DOMAIN
+from .const import COORDINATORS, DOMAIN, API_COOLDOWN_IN_SECONDS
 from .coordinator import MySkodaDataUpdateCoordinator
 from .entity import MySkodaEntity
 from .utils import InvalidCapabilityConfigurationError, add_supported_entities
@@ -94,6 +96,7 @@ class MySkodaClimate(MySkodaEntity, ClimateEntity):
             return None
         return target_temperature.temperature_value
 
+    @Throttle(timedelta(seconds=API_COOLDOWN_IN_SECONDS))
     async def async_set_hvac_mode(self, hvac_mode: HVACMode):  # noqa: D102
         target_temperature = self._air_conditioning().target_temperature
         if target_temperature is None:

--- a/custom_components/myskoda/climate.py
+++ b/custom_components/myskoda/climate.py
@@ -117,6 +117,7 @@ class MySkodaClimate(MySkodaEntity, ClimateEntity):
     async def async_turn_off(self):  # noqa: D102
         await self.async_set_hvac_mode(HVACMode.OFF)
 
+    @Throttle(timedelta(seconds=API_COOLDOWN_IN_SECONDS))
     async def async_set_temperature(self, **kwargs):  # noqa: D102
         temp = kwargs[ATTR_TEMPERATURE]
         await self.coordinator.myskoda.set_target_temperature(

--- a/custom_components/myskoda/device_tracker.py
+++ b/custom_components/myskoda/device_tracker.py
@@ -1,10 +1,12 @@
 """Device Tracker entities for MySkoda."""
 
-from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.components.device_tracker.config_entry import (
+    TrackerEntity,
+    TrackerEntityDescription,
+)
 from homeassistant.components.device_tracker.const import SourceType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
 from myskoda.models.info import CapabilityId
@@ -35,7 +37,7 @@ class DeviceTracker(MySkodaEntity, TrackerEntity):
 
     def __init__(self, coordinator: MySkodaDataUpdateCoordinator, vin: str) -> None:  # noqa: D107
         title = coordinator.data.vehicle.info.specification.title
-        self.entity_description = EntityDescription(
+        self.entity_description = TrackerEntityDescription(
             name=title,
             key=f"{vin}_device_tracker",
             translation_key="device_tracker",

--- a/custom_components/myskoda/number.py
+++ b/custom_components/myskoda/number.py
@@ -12,10 +12,12 @@ from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType
+from homeassistant.util import Throttle
 from myskoda.models.charging import Settings
 from myskoda.models.info import CapabilityId
+from datetime import timedelta
 
-from .const import COORDINATORS, DOMAIN
+from .const import COORDINATORS, DOMAIN, API_COOLDOWN_IN_SECONDS
 from .entity import MySkodaEntity
 from .utils import InvalidCapabilityConfigurationError, add_supported_entities
 
@@ -76,6 +78,7 @@ class ChargeLimit(MySkodaNumber):
     def native_value(self) -> float | None:  # noqa: D102
         return self._settings().target_state_of_charge_in_percent
 
+    @Throttle(timedelta(seconds=API_COOLDOWN_IN_SECONDS))
     async def async_set_native_value(self, value: float):  # noqa: D102
         await self.coordinator.myskoda.set_charge_limit(
             self.vehicle.info.vin, int(value)


### PR DESCRIPTION
Currently, every climate change, including a slider from the UI, results in a request to the car.
Given that the car has limited capabilities to handle many requests, we should limit those.

This introduces a HA mechanism called 'Throttle'. Basically, this means all requests after the first one are ignored for a timeperiod. Introducing this with 30s timeperiod.