### PR TITLE
Add various suggestions from ludeeus/integration_blueprint

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,41 @@
+{
+    "name": "skodaconnect/homeassistant-myskoda",
+    "image": "mcr.microsoft.com/devcontainers/python:3.12",
+    "postCreateCommand": "scripts/setup",
+    "forwardPorts": [
+        8123
+    ],
+    "portsAttributes": {
+        "8123": {
+            "label": "Home Assistant",
+            "onAutoForward": "notify"
+        }
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "charliermarsh.ruff",
+                "github.vscode-pull-request-github",
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "ryanluker.vscode-coverage-gutters"
+            ],
+            "settings": {
+                "files.eol": "\n",
+                "editor.tabSize": 4,
+                "editor.formatOnPaste": true,
+                "editor.formatOnSave": true,
+                "editor.formatOnType": false,
+                "files.trimTrailingWhitespace": true,
+                "python.analysis.typeCheckingMode": "basic",
+                "python.analysis.autoImportCompletions": true,
+                "python.defaultInterpreterPath": "/usr/local/bin/python",
+                "[python]": {
+                    "editor.defaultFormatter": "charliermarsh.ruff"
+                }
+            }
+        }
+    },
+    "remoteUser": "vscode",
+    "features": {}
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # Dependabot should not update Home Assistant as that should match the homeassistant key in hacs.json
+      - dependency-name: "homeassistant"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: "Release"
+
+on:
+  release:
+    types:
+      - "published"
+
+permissions: {}
+
+jobs:
+  release:
+    name: "Release"
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: write
+    steps:
+      - name: "Checkout the repository"
+        uses: "actions/checkout@v4.1.7"
+
+      - name: "ZIP the integration directory"
+        shell: "bash"
+        run: |
+          cd "${{ github.workspace }}/custom_components/homeassistant-myskoda"
+          zip homeassistant-myskoda.zip -r ./
+
+      - name: "Upload the ZIP file to the release"
+        uses: "softprops/action-gh-release@v2.0.8"
+        with:
+          files: ${{ github.workspace }}/custom_components/homeassistant-myskoda/homeassistant-myskoda.zip

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -2,7 +2,11 @@ name: Validate
 
 on:
   push: 
+    branches:
+      - "main"
   pull_request:
+    branches:
+      - "main"
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,18 @@
+# artifacts
 __pycache__
+.pytest*
+*.egg-info
+*/build/*
+*/dist/*
+
+# misc
+.coverage
+.vscode
+coverage.xml
+.ruff_cache
 *.code-workspace
 venv
-.vscode/PythonImportHelper-v2-Completion.json
+
+# Home Assistant configuration
+config/*
+!config/configuration.yaml

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,11 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run Home Assistant on port 8123",
+            "type": "shell",
+            "command": "scripts/develop",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -1,0 +1,12 @@
+# https://www.home-assistant.io/integrations/default_config/
+default_config:
+
+# https://www.home-assistant.io/integrations/homeassistant/
+homeassistant:
+  debug: true
+
+# https://www.home-assistant.io/integrations/logger/
+logger:
+  default: info
+  logs:
+    custom_components.integration_blueprint: debug

--- a/poetry.lock
+++ b/poetry.lock
@@ -3113,4 +3113,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12"
-content-hash = "2dfe41147335736e094216fb3e5cb138519e779d0114d89787728cf45d43da4a"
+content-hash = "eaa178e84f0485235af79ccf644d4d0e6b55d3080ea911a91dc05536e18425a8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ myskoda = "^0.7.2"
 
 
 [tool.poetry.group.dev.dependencies]
-ruff = "^0.6.4"
-homeassistant-stubs = "^2024.9.1"
+ruff = "^0.6.7"
+homeassistant-stubs = "^2024.10.0"
 pyright = "^1.1.379"
 
 [build-system]

--- a/scripts/develop
+++ b/scripts/develop
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+# Create config dir if not present
+if [[ ! -d "${PWD}/config" ]]; then
+    mkdir -p "${PWD}/config"
+    hass --config "${PWD}/config" --script ensure_config
+fi
+
+# Set the path to custom_components
+## This let's us have the structure we want <root>/custom_components/integration_blueprint
+## while at the same time have Home Assistant configuration inside <root>/config
+## without resulting to symlinks.
+export PYTHONPATH="${PYTHONPATH}:${PWD}/custom_components"
+
+# Start Home Assistant
+hass --config "${PWD}/config" --debug

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+ruff format .
+ruff check . --fix

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+python3 -m pip install --requirement requirements.txt


### PR DESCRIPTION
This repo is commonly used as a template repo for HACS integrations.
This PR adds from there:

- VSCode devcontainer setup
- Dependabot setup
- Automatic creation of zip archive on release
- Some tweaks to current CI (limits runs to only main branch)