### PR TITLE
Limit workflows so they dont run on forks

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -9,6 +9,7 @@ permissions: write-all
 
 jobs:
   synchronize-with-crowdin:
+    if: github.repository_owner == 'skodaconnect'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   synchronize-with-crowdin:
+    if: github.repository_owner == 'skodaconnect'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ permissions: {}
 
 jobs:
   release:
+    if: github.repository_owner == 'skodaconnect'
     name: "Release"
     runs-on: "ubuntu-latest"
     permissions:


### PR DESCRIPTION
Some workflows do not need to run on forks, since they either hold credentials, or do tasks that are not suited for forks.