### PR TITLE
Update entity names and IDs to include device name

### DIFF
--- a/custom_components/myskoda/entity.py
+++ b/custom_components/myskoda/entity.py
@@ -15,6 +15,7 @@ class MySkodaEntity(CoordinatorEntity):
 
     vin: str
     coordinator: MySkodaDataUpdateCoordinator
+    _attr_has_entity_name = True
 
     def __init__(
         self,


### PR DESCRIPTION
This will cause entity names and IDs to include the vehicle name, making it easier to identify and use the entities, especially when having multiple vehicles. The unique_id does not change.

E.g.

```
entity_description.key = charger_connected
unique_id = TMBXXXXXXXXXXXX_charger_connected
entitiy_id = sensor.skoda_enyaq_charger_connected
name = Skoda Enyaq Charger Connected
```

Reference: https://developers.home-assistant.io/docs/core/entity/#has_entity_name-true-mandatory-for-new-integrations

Fixes #57

This will be a somewhat breaking change in that in order to benefit from the new entitiy names users will need to delete and recreate the integration.

Thanks to @joostlek for the pointer!