### PR TITLE
Migrate Entity icons to icons.json file

### DIFF
--- a/custom_components/myskoda/binary_sensor.py
+++ b/custom_components/myskoda/binary_sensor.py
@@ -86,12 +86,6 @@ class ChargerConnected(AirConditioningBinarySensor):
         if ac := self._air_conditioning():
             return ac.charger_connection_state == common.ConnectionState.CONNECTED
 
-    @property
-    def icon(self) -> str:  # noqa: D102
-        if self.is_on:
-            return "mdi:power-plug"
-        return "mdi:power-plug-off"
-
 
 class ChargerLocked(AirConditioningBinarySensor):
     """Detect if the charger is locked on the car, or whether it can be unplugged."""
@@ -108,12 +102,6 @@ class ChargerLocked(AirConditioningBinarySensor):
         if ac := self._air_conditioning():
             if ac.charger_lock_state != ChargerLockedState.INVALID:
                 return ac.charger_lock_state != common.ChargerLockedState.LOCKED
-
-    @property
-    def icon(self) -> str:  # noqa: D102
-        if self.is_on:
-            return "mdi:lock-open"
-        return "mdi:lock"
 
 
 class Locked(StatusBinarySensor):
@@ -133,12 +121,6 @@ class Locked(StatusBinarySensor):
         if status := self._status():
             return not status.overall.locked == DoorLockedState.LOCKED
 
-    @property
-    def icon(self) -> str:  # noqa: D102
-        if self.is_on:
-            return "mdi:lock-open"
-        return "mdi:lock"
-
 
 class DoorsLocked(StatusBinarySensor):
     """Detect whether the doors are locked."""
@@ -155,12 +137,6 @@ class DoorsLocked(StatusBinarySensor):
         if status := self._status():
             return not status.overall.doors_locked == DoorLockedState.LOCKED
 
-    @property
-    def icon(self) -> str:  # noqa: D102
-        if self.is_on:
-            return "mdi:car-door-lock-open"
-        return "mdi:car-door-lock"
-
 
 class DoorsOpen(StatusBinarySensor):
     """Detects whether at least one door is open."""
@@ -169,7 +145,6 @@ class DoorsOpen(StatusBinarySensor):
         key="doors_open",
         name="Doors",
         device_class=BinarySensorDeviceClass.DOOR,
-        icon="mdi:car-door",
         translation_key="doors_open",
     )
 
@@ -186,7 +161,6 @@ class WindowsOpen(StatusBinarySensor):
         key="windows_open",
         name="Windows",
         device_class=BinarySensorDeviceClass.WINDOW,
-        icon="mdi:car-door",
         translation_key="windows_open",
     )
 
@@ -203,7 +177,6 @@ class TrunkOpen(StatusBinarySensor):
         key="trunk_open",
         name="Trunk",
         device_class=BinarySensorDeviceClass.OPENING,
-        icon="mdi:car",
         translation_key="trunk_open",
     )
 
@@ -220,7 +193,6 @@ class BonnetOpen(StatusBinarySensor):
         key="bonnet_open",
         name="Bonnet",
         device_class=BinarySensorDeviceClass.OPENING,
-        icon="mdi:car",
         translation_key="bonnet_open",
     )
 
@@ -237,7 +209,6 @@ class SunroofOpen(StatusBinarySensor):
         key="sunroof_open",
         name="Sunroof",
         device_class=BinarySensorDeviceClass.OPENING,
-        icon="mdi:car-select",
     )
 
     @property
@@ -266,7 +237,6 @@ class LightsOn(StatusBinarySensor):
         key="lights_on",
         name="Lights",
         device_class=BinarySensorDeviceClass.LIGHT,
-        icon="mdi:car-light-high",
         translation_key="lights_on",
     )
 

--- a/custom_components/myskoda/climate.py
+++ b/custom_components/myskoda/climate.py
@@ -47,7 +47,6 @@ class MySkodaClimate(MySkodaEntity, ClimateEntity):
     entity_description = ClimateEntityDescription(
         key="climate",
         name="Air Conditioning",
-        icon="mdi:air-conditioner",
         translation_key="climate",
     )
     _attr_temperature_unit = UnitOfTemperature.CELSIUS

--- a/custom_components/myskoda/icons.json
+++ b/custom_components/myskoda/icons.json
@@ -3,14 +3,18 @@
 		"sensor": {
 			"charge_type": {
 				"default": "mdi:ev-plug-type2",
-				"dc": "mdi:ev-plug-ccs2"
+				"state": {
+				    "dc": "mdi:ev-plug-ccs2"
+				}
 			},
 			"charging_state": {
 				"default": "mdi:power-plug",
-				"connect_cable": "mdi:power-plug-off",
-				"charging": "mdi:power-plug-battery",
-				"conserving": "mdi:battery-sync",
-				"ready_for_charging": "mdi:battery-check"
+				"state": {
+				    "connect_cable": "mdi:power-plug-off",
+				    "charging": "mdi:power-plug-battery",
+				    "conserving": "mdi:battery-sync",
+				    "ready_for_charging": "mdi:battery-check"
+				}
 			}
 		}
 	}

--- a/custom_components/myskoda/icons.json
+++ b/custom_components/myskoda/icons.json
@@ -42,7 +42,8 @@
 			},
 			"windows_open": {
 				"default": "mdi:car-door"
-			},
+			}
+		},
 		"climate": {
 			"climate": {
 				"default": "mdi:air-conditioner"

--- a/custom_components/myskoda/icons.json
+++ b/custom_components/myskoda/icons.json
@@ -1,0 +1,16 @@
+{
+	"entity": {
+		"sensor": {
+			"charge_type": {
+				"default": "mdi:ev-plug-type2",
+				"dc": "mdi:ev-plug-ccs2"
+			},
+			"charging_state": {
+				"default": "mdi:power-plug",
+				"connect_cable": "mdi:power-plug-off",
+				"charging": "mdi:power-plug-battery",
+				"conserving": "mdi:battery-sync",
+				"ready_for_charging": "mdi:battery-check"
+		}
+	}
+}

--- a/custom_components/myskoda/icons.json
+++ b/custom_components/myskoda/icons.json
@@ -11,6 +11,7 @@
 				"charging": "mdi:power-plug-battery",
 				"conserving": "mdi:battery-sync",
 				"ready_for_charging": "mdi:battery-check"
+			}
 		}
 	}
 }

--- a/custom_components/myskoda/icons.json
+++ b/custom_components/myskoda/icons.json
@@ -1,5 +1,48 @@
 {
 	"entity": {
+		"binary_sensor": {
+			"bonnet_open": {
+				"default": "mdi:car"
+			},
+			"charger_connected": {
+				"default": "mdi:power-plug-off",
+				"state": {
+					"on": "mdi:power-plug"
+				}
+			},
+			"charger_locked": {
+				"default": "mdi:lock",
+				"state": {
+					"on": "mdi:lock-open"
+				}
+			},
+			"doors_locked": {
+				"default": "mdi:car-door-lock",
+				"state": {
+					"on": "mdi:car-door-lock-open"
+				}
+			},
+			"doors_open": {
+				"default": "mdi:car-door"
+			},
+			"lights_on": {
+				"default": "mdi:car-light-high"
+			},
+			"locked": {
+				"default": "mdi:lock",
+				"state": {
+					"on": "mdi:lock-open"
+				}
+			},
+			"sunroof_open": {
+				"default": "mdi:car-select"
+			},
+			"trunk_open": {
+				"default": "mdi:car"
+			},
+			"windows_open": {
+				"default": "mdi:car-door"
+			},
 		"climate": {
 			"climate": {
 				"default": "mdi:air-conditioner"

--- a/custom_components/myskoda/icons.json
+++ b/custom_components/myskoda/icons.json
@@ -1,11 +1,26 @@
 {
 	"entity": {
+		"climate": {
+			"climate": {
+				"default": "mdi:air-conditioner"
+			}
+		},
+		"device_tracker": {
+			"device_tracker": {
+				"default": "mdi:map-marker"
+			}
+		},
+		"number": {
+			"charge_limit": {
+				"default": "mdi:battery-lock"
+			}
+		},
 		"sensor": {
-			"charge_type": {
-				"default": "mdi:ev-plug-type2",
-				"state": {
-				    "dc": "mdi:ev-plug-ccs2"
-				}
+			"car_captured": {
+				"default": "mdi:clock"
+			},
+			"charge_power": {
+				"default": "mdi:lightning-bolt"
 			},
 			"charging_state": {
 				"default": "mdi:power-plug",
@@ -14,6 +29,65 @@
 				    "charging": "mdi:power-plug-battery",
 				    "conserving": "mdi:battery-sync",
 				    "ready_for_charging": "mdi:battery-check"
+				}
+			},
+			"charge_type": {
+				"default": "mdi:ev-plug-type2",
+				"state": {
+				    "dc": "mdi:ev-plug-ccs2"
+				}
+			},
+			"inspection": {
+				"default": "mdi:car-wrench"
+			},
+			"mileage": {
+				"default": "mdi:counter"
+			},
+			"range": {
+				"default": "mdi:speedometer"
+			},
+			"remaining_charging_time": {
+				"default": "mdi:timer"
+			},
+			"render_url_main": {
+				"default": "mdi:file-image"
+			},
+			"software_version": {
+				"default": "mdi:update"
+			},
+			"target_battery_percentage": {
+				"default": "mdi:percent"
+			}
+		},
+		"switch": {
+			"battery_care_mode": {
+				"default": "mdi:battery-heart-variant",
+				"state": {
+					"off": "mdi:battery-plus"
+				}
+			},
+			"charging": {
+				"default": "mdi:power-plug-battery",
+				"state": {
+					"off": "mdi:power-plug-battery-outline"
+				}
+			},
+			"charging_switch": {
+				"default": "mdi:car-electric",
+				"state": {
+					"off": "mdi:car-electric-outline"
+				}
+			},
+			"reduced_current": {
+				"default": "mdi:current-ac",
+				"state": {
+					"on": "mdi:turle"
+				}
+			},
+			"window_heating": {
+				"default": "mdi:car-defrost-front",
+				"state": {
+					"on": "mdi:heat-wave"
 				}
 			}
 		}

--- a/custom_components/myskoda/number.py
+++ b/custom_components/myskoda/number.py
@@ -56,7 +56,6 @@ class ChargeLimit(MySkodaNumber):
     entity_description = NumberEntityDescription(
         key="charge_limit",
         name="Charge Limit",
-        icon="mdi:battery-lock",
         native_max_value=100,
         native_min_value=50,
         native_unit_of_measurement=PERCENTAGE,

--- a/custom_components/myskoda/sensor.py
+++ b/custom_components/myskoda/sensor.py
@@ -254,14 +254,6 @@ class ChargeType(ChargingSensor):
         if status := self._status():
             return str(status.charge_type).lower()
 
-    @property
-    def icon(self) -> str:  # noqa: D102
-        if status := self._status():
-            if status.charge_type == "DC":
-                return "mdi:ev-plug-ccs2"
-
-        return "mdi:ev-plug-type2"
-
 
 class ChargingState(ChargingSensor):
     """Current state of charging (ready, charging, conserving, ...)."""
@@ -286,15 +278,6 @@ class ChargingState(ChargingSensor):
         if status := self._status():
             if status.state:
                 return str(status.state).lower()
-
-    @property
-    def icon(self) -> str:  # noqa: D102
-        if status := self._status():
-            if status.state == charging.ChargingState.CONNECT_CABLE:
-                return "mdi:power-plug-off"
-            if status.state == charging.ChargingState.CHARGING:
-                return "mdi:power-plug-battery"
-        return "mdi:power-plug"
 
 
 class RemainingChargingTime(ChargingSensor):

--- a/custom_components/myskoda/sensor.py
+++ b/custom_components/myskoda/sensor.py
@@ -9,7 +9,13 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, UnitOfLength, UnitOfPower, UnitOfTime
+from homeassistant.const import (
+    PERCENTAGE,
+    UnitOfLength,
+    UnitOfPower,
+    UnitOfTime,
+    EntityCategory,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType  # pyright: ignore [reportAttributeAccessIssue]
@@ -59,7 +65,6 @@ class SoftwareVersion(MySkodaSensor):
     entity_description = SensorEntityDescription(
         key="software_version",
         name="Software Version",
-        icon="mdi:update",
         translation_key="software_version",
     )
 
@@ -145,7 +150,6 @@ class ChargingPower(ChargingSensor):
     entity_description = SensorEntityDescription(
         key="charging_power",
         name="Charging Power",
-        icon="mdi:lightning-bolt",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         device_class=SensorDeviceClass.POWER,
@@ -164,7 +168,6 @@ class RemainingDistance(ChargingSensor):
     entity_description = SensorEntityDescription(
         key="range",
         name="Range",
-        icon="mdi:speedometer",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfLength.KILOMETERS,
         device_class=SensorDeviceClass.DISTANCE,
@@ -185,7 +188,6 @@ class TargetBatteryPercentage(ChargingSensor):
         name="Target Battery Percentage",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PERCENTAGE,
-        icon="mdi:percent",
         device_class=SensorDeviceClass.BATTERY,
         translation_key="target_battery_percentage",
     )
@@ -204,7 +206,6 @@ class Mileage(MySkodaSensor):
         name="Milage",
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfLength.KILOMETERS,
-        icon="mdi:counter",
         device_class=SensorDeviceClass.DISTANCE,
         translation_key="milage",
     )
@@ -227,7 +228,6 @@ class InspectionInterval(MySkodaSensor):
         device_class=SensorDeviceClass.DURATION,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTime.DAYS,
-        icon="mdi:car-wrench",
         translation_key="inspection",
     )
 
@@ -288,7 +288,6 @@ class RemainingChargingTime(ChargingSensor):
         name="Remaining Charging Time",
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.MINUTES,
-        icon="mdi:timer",
         translation_key="remaining_charging_time",
     )
 
@@ -305,7 +304,6 @@ class LastUpdated(MySkodaSensor):
         key="car_captured",
         name="Last Updated",
         device_class=SensorDeviceClass.TIMESTAMP,
-        icon="mdi:clock",
         translation_key="car_captured",
     )
 
@@ -324,8 +322,8 @@ class MainRender(MySkodaSensor):
     entity_description = SensorEntityDescription(
         key="render_url_main",
         name="Main Render URL",
-        icon="mdi:file-image",
         translation_key="render_url_main",
+        entity_category=EntityCategory.DIAGNOSTIC,
     )
 
     @property

--- a/custom_components/myskoda/switch.py
+++ b/custom_components/myskoda/switch.py
@@ -62,7 +62,6 @@ class WindowHeating(MySkodaSwitch):
     entity_description = SwitchEntityDescription(
         key="window_heating",
         name="Window Heating",
-        icon="mdi:car-defrost-front",
         device_class=SwitchDeviceClass.SWITCH,
         translation_key="window_heating",
     )
@@ -101,7 +100,6 @@ class ChargingSwitch(MySkodaSwitch):
     entity_description = SwitchEntityDescription(
         key="charging_switch",
         name="Charging",
-        icon="mdi:car-electric",
         device_class=SwitchDeviceClass.SWITCH,
         translation_key="charging_switch",
     )
@@ -129,7 +127,6 @@ class BatteryCareMode(ChargingSwitch):
     entity_description = SwitchEntityDescription(
         key="battery_care_mode",
         name="Battery Care Mode",
-        icon="mdi:battery-heart-variant",
         device_class=SwitchDeviceClass.SWITCH,
         translation_key="battery_care_mode",
     )
@@ -166,7 +163,6 @@ class ReducedCurrent(ChargingSwitch):
     entity_description = SwitchEntityDescription(
         key="reduced_current",
         name="Reduced Current",
-        icon="mdi:current-ac",
         device_class=SwitchDeviceClass.SWITCH,
         translation_key="reduced_current",
     )
@@ -203,7 +199,6 @@ class EnableCharging(ChargingSwitch):
     entity_description = SwitchEntityDescription(
         key="charging",
         name="Charging",
-        icon="mdi:power-plug-battery",
         device_class=SwitchDeviceClass.SWITCH,
         translation_key="charging",
     )


### PR DESCRIPTION
To better align with https://developers.home-assistant.io/blog/2024/01/19/icon-translations

Also made the URL render entity a diagnostic entity, no ordinary user would need to see this on a daily basis.