### PR TITLE
Removing projects we no longer directly depend on

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3098,4 +3098,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12,<3.13"
-content-hash = "b4fe6d299e40e9118db6c4e3dc3f2aa5bbd4f8e45ce94f321be55a7d5f812b73"
+content-hash = "eb4bd81948fa4e4b9bfd5bb4d142236ece1e453373cef849b0fda23a52de85bc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,6 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "~3.12,<3.13"
 homeassistant = "^2024.10.0"
-aiohttp = "^3.10.5"
-pyjwt = "^2.9.0"
-pyyaml = "^6.0.2"
-asyncio = "^3.4.3"
 voluptuous = "^0.15.2"
 myskoda = "^0.8.4"
 


### PR DESCRIPTION
Just let HomeAssistant deal with the dependencies so we don't need to