### PR TITLE
(ci) Add pyright to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,10 @@ repos:
     hooks:
       - id: ruff
       - id: ruff-format
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.385
+    hooks:
+      - id: pyright
   - repo: https://github.com/python-poetry/poetry
     rev: 1.8.3
     hooks:


### PR DESCRIPTION
This adds pyright to pre-commit, so it runs locally before every commit done.