### PR TITLE
Fix typo in Mileage sensor

### DIFF
--- a/custom_components/myskoda/sensor.py
+++ b/custom_components/myskoda/sensor.py
@@ -206,7 +206,7 @@ class Mileage(MySkodaSensor):
         native_unit_of_measurement=UnitOfLength.KILOMETERS,
         icon="mdi:counter",
         device_class=SensorDeviceClass.DISTANCE,
-        translation_key="milage",
+        translation_key="mileage",
     )
 
     @property


### PR DESCRIPTION
The translation for the Mileage sensor was not working due to a typo.