### PR TITLE
Change mainrender sensor to image

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,6 @@ repos:
     hooks:
       - id: ruff
       - id: ruff-format
-  - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.385
-    hooks:
-      - id: pyright
   - repo: https://github.com/python-poetry/poetry
     rev: 1.8.3
     hooks:

--- a/custom_components/myskoda/__init__.py
+++ b/custom_components/myskoda/__init__.py
@@ -24,6 +24,7 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
     Platform.NUMBER,
     Platform.BINARY_SENSOR,
+    Platform.IMAGE,
 ]
 
 

--- a/custom_components/myskoda/icons.json
+++ b/custom_components/myskoda/icons.json
@@ -59,6 +59,11 @@
 				"default": "mdi:battery-lock"
 			}
 		},
+		"image": {
+			"render_url_main": {
+				"default": "mdi:file-image"
+			}
+		},
 		"sensor": {
 			"car_captured": {
 				"default": "mdi:clock"
@@ -92,9 +97,6 @@
 			},
 			"remaining_charging_time": {
 				"default": "mdi:timer"
-			},
-			"render_url_main": {
-				"default": "mdi:file-image"
 			},
 			"software_version": {
 				"default": "mdi:update"

--- a/custom_components/myskoda/image.py
+++ b/custom_components/myskoda/image.py
@@ -1,0 +1,53 @@
+"""Images for the MySkoda integration."""
+
+from homeassistant.components.image import (
+    ImageEntity,
+    ImageEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    EntityCategory,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import DiscoveryInfoType  # pyright: ignore [reportAttributeAccessIssue]
+
+
+from .const import COORDINATORS, DOMAIN
+from .entity import MySkodaEntity
+from .utils import add_supported_entities
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+    _discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the sensor platform."""
+    add_supported_entities(
+        available_entities=[
+            MainRenderImage,
+        ],
+        coordinators=hass.data[DOMAIN][config.entry_id][COORDINATORS],
+        async_add_entities=async_add_entities,
+    )
+
+
+class MySkodaImage(MySkodaEntity, ImageEntity):
+    pass
+
+
+class MainRenderImage(MySkodaImage):
+    """Main render of the vehicle."""
+
+    entity_description = ImageEntityDescription(
+        key="render_vehicle_main",
+        name="Main Vehicle Render",
+        translation_key="render_vehicle_main",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    )
+
+    @property
+    def image_url(self):  # noqa: D102
+        return self.get_renders().get("main")

--- a/custom_components/myskoda/image.py
+++ b/custom_components/myskoda/image.py
@@ -1,5 +1,7 @@
 """Images for the MySkoda integration."""
 
+import logging
+
 from homeassistant.components.image import (
     ImageEntity,
     ImageEntityDescription,
@@ -12,30 +14,37 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType  # pyright: ignore [reportAttributeAccessIssue]
 
-
 from .const import COORDINATORS, DOMAIN
+from .coordinator import MySkodaDataUpdateCoordinator
 from .entity import MySkodaEntity
 from .utils import add_supported_entities
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
     config: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
-    _discovery_info: DiscoveryInfoType | None = None,
+    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up the sensor platform."""
+    """Set up the image platform."""
     add_supported_entities(
-        available_entities=[
-            MainRenderImage,
-        ],
+        available_entities=[MainRenderImage],
         coordinators=hass.data[DOMAIN][config.entry_id][COORDINATORS],
         async_add_entities=async_add_entities,
     )
 
 
 class MySkodaImage(MySkodaEntity, ImageEntity):
-    pass
+    """Representation of an Image for MySkoda."""
+
+    def __init__(
+        self, hass: HomeAssistant, coordinator: MySkodaDataUpdateCoordinator, vin: str
+    ) -> None:
+        """Initialize the Image for MySkoda."""
+        ImageEntity.__init__(hass)
+        super().__init__(self.coordinator, self.vin)
 
 
 class MainRenderImage(MySkodaImage):
@@ -49,5 +58,5 @@ class MainRenderImage(MySkodaImage):
     )
 
     @property
-    def image_url(self):  # noqa: D102
+    def image_url(self) -> str | None:
         return self.get_renders().get("main")

--- a/custom_components/myskoda/sensor.py
+++ b/custom_components/myskoda/sensor.py
@@ -14,7 +14,6 @@ from homeassistant.const import (
     UnitOfLength,
     UnitOfPower,
     UnitOfTime,
-    EntityCategory,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -43,7 +42,6 @@ async def async_setup_entry(
             ChargingPower,
             ChargingState,
             LastUpdated,
-            MainRender,
             Mileage,
             RemainingChargingTime,
             RemainingDistance,
@@ -314,18 +312,3 @@ class LastUpdated(MySkodaSensor):
 
     def required_capabilities(self) -> list[CapabilityId]:
         return [CapabilityId.STATE]
-
-
-class MainRender(MySkodaSensor):
-    """URL of the main image render of the vehicle."""
-
-    entity_description = SensorEntityDescription(
-        key="render_url_main",
-        name="Main Render URL",
-        translation_key="render_url_main",
-        entity_category=EntityCategory.DIAGNOSTIC,
-    )
-
-    @property
-    def native_value(self):  # noqa: D102
-        return self.get_renders().get("main")

--- a/custom_components/myskoda/translations/en.json
+++ b/custom_components/myskoda/translations/en.json
@@ -65,6 +65,11 @@
                 "name": "Charge Limit"
 	    }
 	},
+	"image": {
+	    "render_vehicle_main": {
+		"name": "Main Render of Vehicle"
+	    }
+	},
 	"sensor": {
 	    "software_version": {
                 "name": "Software Version"


### PR DESCRIPTION
As indicated in #129 the current display of the render image is not really nice.
This turns it from a `SensorEntity` into an actual `ImageEntity` as HomeAssistant understands it.

![image](https://github.com/user-attachments/assets/8968375a-b9f6-4379-b50b-2c45bf504fdc)

Additionally, this reverts #118 since it broke precommit in an environment with virtualenvs.
