### PR TITLE
Fix value of charge_type sensor

### DIFF
--- a/custom_components/myskoda/sensor.py
+++ b/custom_components/myskoda/sensor.py
@@ -250,7 +250,8 @@ class ChargeType(ChargingSensor):
     @property
     def native_value(self) -> str | None:  # noqa: D102
         if status := self._status():
-            return str(status.charge_type).lower()
+            if status.charge_type:
+                return str(status.charge_type).lower()
 
 
 class ChargingState(ChargingSensor):

--- a/custom_components/myskoda/translations/en.json
+++ b/custom_components/myskoda/translations/en.json
@@ -99,7 +99,12 @@
 		"name": "Mileage"
 	    },
 	    "charge_type": {
-		"name": "Charge Type"
+		"name": "Charge Type",
+		"state": {
+			"ac": "AC",
+			"dc": "DC",
+			"off": "OFF"
+		}
 	    },
 	    "remaining_charging_time": {
 		"name": "Remaining Charging Time"


### PR DESCRIPTION
Currently, the value of the `charge_type` sensor is always a string, reporting "none" when no charging is happening.

This changes the behaviour to:
- Lowercase value ac/dc/off when we get a reply
- Unknown when we do not get a reply
- Adds translation for ac/dc/off