### PR TITLE
Add translation key for sunroof

### DIFF
--- a/custom_components/myskoda/binary_sensor.py
+++ b/custom_components/myskoda/binary_sensor.py
@@ -200,6 +200,7 @@ class SunroofOpen(StatusBinarySensor):
     entity_description = BinarySensorEntityDescription(
         key="sunroof_open",
         device_class=BinarySensorDeviceClass.OPENING,
+        translation_key="sunroof_open",
     )
 
     @property


### PR DESCRIPTION
Sunroof was accidentally untranslated and would list as 'Opening'