### PR TITLE
Add forbidden capabilities

### DIFF
--- a/custom_components/myskoda/entity.py
+++ b/custom_components/myskoda/entity.py
@@ -46,9 +46,17 @@ class MySkodaEntity(CoordinatorEntity):
     def required_capabilities(self) -> list[CapabilityId]:
         return []
 
+    def forbidden_capabilities(self) -> list[CapabilityId]:
+        return []
+
     def is_supported(self) -> bool:
         return all(
             self.vehicle.has_capability(cap) for cap in self.required_capabilities()
+        )
+
+    def is_forbidden(self) -> bool:
+        return all(
+            self.vehicle.has_capability(cap) for cap in self.forbidden_capabilities()
         )
 
     def get_renders(self) -> dict[str, str]:

--- a/custom_components/myskoda/utils.py
+++ b/custom_components/myskoda/utils.py
@@ -18,7 +18,8 @@ def add_supported_entities(
     for vin in coordinators:
         for SensorClass in available_entities:
             sensor = SensorClass(coordinators[vin], vin)
-            if sensor.is_supported():
-                entities.append(sensor)
+            if not sensor.is_forbidden():
+                if sensor.is_supported():
+                    entities.append(sensor)
 
     async_add_entities(entities, update_before_add=True)


### PR DESCRIPTION
Forbidden capabilities are capabilities that cannot be present for a sensor to be added.
They are effectively the reverse of required capabilities, that must be present for a sensor to be added.

The logic added in this PR is follows:

- A sensor will be added when the vehicle has *none* of the capabilities in forbidden capabilities and *all* of the capabilities in required capabilities

Example here is the battery-care switch for a Superb iV:
The Superb iV does not have the function, but it does support the CHARGING capability.

When you add the CHARGING_MQB capability to the forbidden capabilities, the battery-care switch will now never be added for the Superb iV: