### PR TITLE
Autofix: Polling interval is in seconds while configuration windows says it is in minutes

### DIFF
--- a/custom_components/myskoda/config_flow.py
+++ b/custom_components/myskoda/config_flow.py
@@ -43,11 +43,10 @@ async def validate_options_input(
 
     if CONF_POLL_INTERVAL in user_input:
         polling_interval: int = user_input[CONF_POLL_INTERVAL]
-        if CONF_POLL_INTERVAL_MIN <= polling_interval <= CONF_POLL_INTERVAL_MAX:
-            return user_input
-        raise SchemaFlowError("invalid_polling_interval")
-
+        if not CONF_POLL_INTERVAL_MIN <= polling_interval <= CONF_POLL_INTERVAL_MAX:
+            raise SchemaFlowError("invalid_polling_interval")
     return user_input
+    if CONF_POLL_INTERVAL in user_input:
 
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> None:
@@ -66,8 +65,10 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 OPTIONS_SCHEMA = vol.Schema(
     {
         vol.Required("tracing", default=False): bool,
+        vol.Optional(CONF_POLL_INTERVAL, default=DEFAULT_FETCH_INTERVAL_IN_MINUTES): vol.All(
+            vol.Coerce(int), vol.Range(min=CONF_POLL_INTERVAL_MIN, max=CONF_POLL_INTERVAL_MAX)
+        ),
         vol.Optional(CONF_POLL_INTERVAL): int,
-    }
 )
 OPTIONS_FLOW = {
     "init": SchemaFlowFormStep(

--- a/custom_components/myskoda/const.py
+++ b/custom_components/myskoda/const.py
@@ -3,9 +3,11 @@
 DOMAIN = "myskoda"
 COORDINATORS = "coordinators"
 
+DEFAULT_FETCH_INTERVAL_IN_MINUTES = 30  # Default polling interval in minutes
 DEFAULT_FETCH_INTERVAL_IN_MINUTES = 30
 API_COOLDOWN_IN_SECONDS = 30.0
 
+CONF_POLL_INTERVAL = "poll_interval"  # Changed to a more generic name
 CONF_POLL_INTERVAL = "poll_interval_in_minutes"
 CONF_POLL_INTERVAL_MIN = 1
 CONF_POLL_INTERVAL_MAX = 1440

--- a/custom_components/myskoda/coordinator.py
+++ b/custom_components/myskoda/coordinator.py
@@ -70,10 +70,10 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(
                 seconds=config.options.get(
                     CONF_POLL_INTERVAL, DEFAULT_FETCH_INTERVAL_IN_MINUTES
-                )
+                ) * 60  # Convert minutes to seconds
+            update_interval=timedelta(
             ),
             always_update=False,
         )


### PR DESCRIPTION
The polling interval is currently being set in seconds instead of minutes as indicated in the configuration window. We need to modify the code to convert the user-specified minutes to seconds when setting the update interval. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    