### PR TITLE
Update translations for charging state connect_cable

### DIFF
--- a/custom_components/myskoda/translations/cs.json
+++ b/custom_components/myskoda/translations/cs.json
@@ -140,7 +140,7 @@
                 "name": "Stav nabíjení",
                 "state": {
                     "charging": "Nabíjení",
-                    "connect_cable": "Kabel odpojen",
+                    "connect_cable": "Žádná síla",
                     "conserving": "Uchovávání nabití",
                     "ready_for_charging": "Připraveno k nabíjení"
                 }

--- a/custom_components/myskoda/translations/da.json
+++ b/custom_components/myskoda/translations/da.json
@@ -140,7 +140,7 @@
                 "name": "Ladestatus",
                 "state": {
                     "charging": "Oplader",
-                    "connect_cable": "Kabel Frakoblet",
+                    "connect_cable": "Ingen strøm",
                     "conserving": "Holder opladning",
                     "ready_for_charging": "Klar til opladning"
                 }

--- a/custom_components/myskoda/translations/de.json
+++ b/custom_components/myskoda/translations/de.json
@@ -140,7 +140,7 @@
                 "name": "Ladestatus",
                 "state": {
                     "charging": "Laden",
-                    "connect_cable": "Ladekabel getrennt",
+                    "connect_cable": "Kein Strom",
                     "conserving": "Ladestand halten",
                     "ready_for_charging": "Bereit zum Laden"
                 }

--- a/custom_components/myskoda/translations/en.json
+++ b/custom_components/myskoda/translations/en.json
@@ -133,21 +133,21 @@
             "charging_power": {
                 "name": "Charging Power"
             },
-	    "charging_rate": {
-		"name": "Charging Rate"
-	    },
+            "charging_rate": {
+                "name": "Charging Rate"
+            },
             "charging_state": {
                 "name": "Charging State",
                 "state": {
                     "charging": "Charging",
-                    "connect_cable": "Cable Disconnected",
+                    "connect_cable": "No Power",
                     "conserving": "Conserving Charge",
                     "ready_for_charging": "Ready for Charging"
                 }
             },
-	    "inspection": {
-		"name": "Next Inspection"
-	    },
+            "inspection": {
+                "name": "Next Inspection"
+            },
             "mileage": {
                 "name": "Mileage"
             },
@@ -183,18 +183,18 @@
         }
     },
     "options": {
-	"error": {
-	    "invalid_polling_interval": "Invalid polling interval specified. Please choose between 1 and 1440 minutes"
-	},
+        "error": {
+            "invalid_polling_interval": "Invalid polling interval specified. Please choose between 1 and 1440 minutes"
+        },
         "step": {
             "init": {
                 "data": {
                     "tracing": "API response tracing. Requires debug logging enabled in configuration.yaml.",
-		    "poll_interval_in_minutes": "Polling interval in minutes when car is idle."
+                    "poll_interval_in_minutes": "Polling interval in minutes when car is idle."
                 },
-		"data_description": {
-		    "poll_interval_in_minutes": "Specify a polling interval between 1 and 1440 minutes. (default 30)"
-		}
+                "data_description": {
+                    "poll_interval_in_minutes": "Specify a polling interval between 1 and 1440 minutes. (default 30)"
+                }
             }
         }
     }

--- a/custom_components/myskoda/translations/fi.json
+++ b/custom_components/myskoda/translations/fi.json
@@ -137,7 +137,7 @@
                 "name": "Latauksen tila",
                 "state": {
                     "charging": "Ladataan",
-                    "connect_cable": "Kaapeli irti",
+                    "connect_cable": "Ei virtaa",
                     "conserving": "Rajoitettu lataus",
                     "ready_for_charging": "Valmis lataamaan"
                 }

--- a/custom_components/myskoda/translations/hu.json
+++ b/custom_components/myskoda/translations/hu.json
@@ -140,7 +140,7 @@
                 "name": "Töltés állapota",
                 "state": {
                     "charging": "Töltődik",
-                    "connect_cable": "Töltőkábel lecsatlakoztatva",
+                    "connect_cable": "Nincs erő",
                     "conserving": "Szintentartó töltés",
                     "ready_for_charging": "Kész a töltésre"
                 }

--- a/custom_components/myskoda/translations/it.json
+++ b/custom_components/myskoda/translations/it.json
@@ -137,7 +137,7 @@
                 "name": "Stato di carica",
                 "state": {
                     "charging": "Ricarica",
-                    "connect_cable": "Cavo disconnesso",
+                    "connect_cable": "Nessun potere",
                     "conserving": "Conservazione della carica",
                     "ready_for_charging": "Pronto per la ricarica"
                 }

--- a/custom_components/myskoda/translations/nl.json
+++ b/custom_components/myskoda/translations/nl.json
@@ -140,7 +140,7 @@
                 "name": "Laadstatus",
                 "state": {
                     "charging": "Opladen",
-                    "connect_cable": "Kabel verbinding verbroken",
+                    "connect_cable": "Geen stroom",
                     "conserving": "Lading bewaren",
                     "ready_for_charging": "Klaar om op te laden"
                 }

--- a/custom_components/myskoda/translations/no.json
+++ b/custom_components/myskoda/translations/no.json
@@ -137,7 +137,7 @@
                 "name": "Ladestatus",
                 "state": {
                     "charging": "Lader",
-                    "connect_cable": "Kabel frakoblet",
+                    "connect_cable": "Ingen strøm",
                     "conserving": "Konserverer lading",
                     "ready_for_charging": "Klar for lading"
                 }

--- a/custom_components/myskoda/translations/pt-BR.json
+++ b/custom_components/myskoda/translations/pt-BR.json
@@ -140,7 +140,7 @@
                 "name": "Estado de carga",
                 "state": {
                     "charging": "Carregando",
-                    "connect_cable": "Cabo desconectado",
+                    "connect_cable": "Sem energia",
                     "conserving": "Conservando carga",
                     "ready_for_charging": "Pronto para carregar"
                 }

--- a/custom_components/myskoda/translations/pt.json
+++ b/custom_components/myskoda/translations/pt.json
@@ -140,7 +140,7 @@
                 "name": "Estado de carga",
                 "state": {
                     "charging": "A carregar",
-                    "connect_cable": "Cabo desconectado",
+                    "connect_cable": "Sem energia",
                     "conserving": "Conservando carga",
                     "ready_for_charging": "Preparado para carregar"
                 }

--- a/custom_components/myskoda/translations/ru.json
+++ b/custom_components/myskoda/translations/ru.json
@@ -137,7 +137,7 @@
                 "name": "Состояние зарядки",
                 "state": {
                     "charging": "Заряжается",
-                    "connect_cable": "Кабель отсоединен",
+                    "connect_cable": "Нет питания",
                     "conserving": "Сохранение заряда",
                     "ready_for_charging": "Готово к зарядке"
                 }

--- a/custom_components/myskoda/translations/sv.json
+++ b/custom_components/myskoda/translations/sv.json
@@ -140,7 +140,7 @@
                 "name": "Laddningstillstånd",
                 "state": {
                     "charging": "Laddar",
-                    "connect_cable": "Kabel frånkopplad",
+                    "connect_cable": "Ingen kraft",
                     "conserving": "Bevara laddning",
                     "ready_for_charging": "Redo för laddning"
                 }


### PR DESCRIPTION
Fixes #137

We may have misunderstood what Skoda and their API mean with a charging status of `CONNECT_CABLE`

We've been assuming it means "You need to connect the cable" but instead it probably means "There is a cable connected but that's it, we're neither charging nor ready to charge".

A better translation is "No Power".

Note that the binary_sensor `charger_connected` already tells us exactly if a charge cable is connected or not.

Translations based on google translate ...