### PR TITLE
Rename lights to parkinglights

### DIFF
--- a/custom_components/myskoda/binary_sensor.py
+++ b/custom_components/myskoda/binary_sensor.py
@@ -226,7 +226,7 @@ class ParkingLightsOn(StatusBinarySensor):
     """Detects whether the parking-lights are on."""
 
     entity_description = BinarySensorEntityDescription(
-        key="parkinglights_on",
+        key="lights_on",
         device_class=BinarySensorDeviceClass.LIGHT,
         translation_key="parkinglights_on",
     )

--- a/custom_components/myskoda/binary_sensor.py
+++ b/custom_components/myskoda/binary_sensor.py
@@ -41,7 +41,7 @@ async def async_setup_entry(
             WindowsOpen,
             TrunkOpen,
             BonnetOpen,
-            LightsOn,
+            ParkingLightsOn,
             ChargerConnected,
             ChargerLocked,
             SunroofOpen,
@@ -222,13 +222,13 @@ class SunroofOpen(StatusBinarySensor):
         return False
 
 
-class LightsOn(StatusBinarySensor):
-    """Detects whether the lights are on."""
+class ParkingLightsOn(StatusBinarySensor):
+    """Detects whether the parking-lights are on."""
 
     entity_description = BinarySensorEntityDescription(
-        key="lights_on",
+        key="parkinglights_on",
         device_class=BinarySensorDeviceClass.LIGHT,
-        translation_key="lights_on",
+        translation_key="parkinglights_on",
     )
 
     @property

--- a/custom_components/myskoda/icons.json
+++ b/custom_components/myskoda/icons.json
@@ -25,14 +25,14 @@
 			"doors_open": {
 				"default": "mdi:car-door"
 			},
-			"lights_on": {
-				"default": "mdi:car-light-high"
-			},
 			"locked": {
 				"default": "mdi:lock",
 				"state": {
 					"on": "mdi:lock-open"
 				}
+			},
+			"parkinglights_on": {
+				"default": "mdi:car-parking-lights"
 			},
 			"sunroof_open": {
 				"default": "mdi:car-select"

--- a/custom_components/myskoda/translations/en.json
+++ b/custom_components/myskoda/translations/en.json
@@ -54,18 +54,18 @@
                     "on": "Open"
                 }
             },
-            "lights_on": {
-                "name": "Lights",
-                "state": {
-                    "off": "Off",
-                    "on": "On"
-                }
-            },
             "locked": {
                 "name": "Vehicle Locked",
                 "state": {
                     "off": "Locked",
                     "on": "Unlocked"
+                }
+            },
+            "parkinglights_on": {
+                "name": "Parking Lights",
+                "state": {
+                    "off": "Off",
+                    "on": "On"
                 }
             },
             "sunroof_open": {


### PR DESCRIPTION
Lights were incorrectly named, as in reality they represent parkinglights.

This removes the lights entity and introduces a new parkinglights entity without any functional change
Fixes #245 

