### PR TITLE
Change range to work with all car types, make icon car-type dependant

### DIFF
--- a/custom_components/myskoda/icons.json
+++ b/custom_components/myskoda/icons.json
@@ -101,9 +101,6 @@
 			"oil_service_in_km": {
 				"default": "mdi:oil"
 			},
-			"range": {
-				"default": "mdi:speedometer"
-			},
 			"remaining_charging_time": {
 				"default": "mdi:timer"
 			},

--- a/custom_components/myskoda/icons.json
+++ b/custom_components/myskoda/icons.json
@@ -92,9 +92,6 @@
 			"mileage": {
 				"default": "mdi:counter"
 			},
-			"range": {
-				"default": "mdi:speedometer"
-			},
 			"remaining_charging_time": {
 				"default": "mdi:timer"
 			},

--- a/custom_components/myskoda/icons.json
+++ b/custom_components/myskoda/icons.json
@@ -101,6 +101,9 @@
 			"oil_service_in_km": {
 				"default": "mdi:oil"
 			},
+			"range": {
+				"default": "mdi:speedometer"
+			},
 			"remaining_charging_time": {
 				"default": "mdi:timer"
 			},

--- a/custom_components/myskoda/icons.json
+++ b/custom_components/myskoda/icons.json
@@ -89,8 +89,17 @@
 			"inspection": {
 				"default": "mdi:car-wrench"
 			},
+			"inspection_in_km": {
+				"default": "mdi:car-wrench"
+			},
 			"mileage": {
 				"default": "mdi:counter"
+			},
+			"oil_service_in_days": {
+				"default": "mdi:oil"
+			},
+			"oil_service_in_km": {
+				"default": "mdi:oil"
 			},
 			"remaining_charging_time": {
 				"default": "mdi:timer"

--- a/custom_components/myskoda/sensor.py
+++ b/custom_components/myskoda/sensor.py
@@ -176,9 +176,11 @@ class RemainingDistance(ChargingSensor):
 
     @property
     def native_value(self) -> int | float | None:  # noqa: D102
-        if status := self._status():
-            if status.battery.remaining_cruising_range_in_meters is not None:
-                return status.battery.remaining_cruising_range_in_meters / 1000
+        if range := self.vehicle.driving_range:
+            return range.total_range_in_km
+            
+    def required_capabilities(self) -> list[CapabilityId]:
+        return [CapabilityId.STATE]
 
 
 class TargetBatteryPercentage(ChargingSensor):

--- a/custom_components/myskoda/sensor.py
+++ b/custom_components/myskoda/sensor.py
@@ -180,7 +180,7 @@ class Range(MySkodaSensor):
 
     @property
     def icon(self) -> str:  # noqa: D102
-        if vehicle.vehicle.driving_range is None or vehicle.vehicle.driving_range.car_type is None:
+        if self.vehicle.driving_range is None or self.vehicle.driving_range.car_type is None:
             return "mdi:gas-station"
         else:
             if self.vehicle.driving_range.car_type == EngineType.ELECTRIC:

--- a/custom_components/myskoda/sensor.py
+++ b/custom_components/myskoda/sensor.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.typing import DiscoveryInfoType  # pyright: ignore [r
 from myskoda.models import charging
 from myskoda.models.charging import Charging, ChargingStatus
 from myskoda.models.info import CapabilityId
+from myskoda.models.driving_range import EngineType
 
 from .const import COORDINATORS, DOMAIN
 from .entity import MySkodaEntity
@@ -46,7 +47,7 @@ async def async_setup_entry(
             LastUpdated,
             Mileage,
             RemainingChargingTime,
-            RemainingDistance,
+            Range,
             SoftwareVersion,
             TargetBatteryPercentage,
             InspectionInterval,
@@ -163,8 +164,8 @@ class ChargingPower(ChargingSensor):
             return status.charge_power_in_kw
 
 
-class RemainingDistance(ChargingSensor):
-    """Estimated range of an electric vehicle in km."""
+class Range(MySkodaSensor):
+    """Estimated range of vehicle in km."""
 
     entity_description = SensorEntityDescription(
         key="range",
@@ -173,6 +174,13 @@ class RemainingDistance(ChargingSensor):
         device_class=SensorDeviceClass.DISTANCE,
         translation_key="range",
     )
+
+    @property
+    def icon(self) -> str:  # noqa: D102
+        if self.vehicle.driving_range.car_type == EngineType.ELECTRIC:
+            return "mdi:ev-station"
+        else:
+            return "mdi:gas-station"
 
     @property
     def native_value(self) -> int | float | None:  # noqa: D102

--- a/custom_components/myskoda/sensor.py
+++ b/custom_components/myskoda/sensor.py
@@ -189,7 +189,7 @@ class Range(MySkodaSensor):
     def native_value(self) -> int | float | None:  # noqa: D102
         if range := self.vehicle.driving_range:
             return range.total_range_in_km
-            
+
     def required_capabilities(self) -> list[CapabilityId]:
         return [CapabilityId.STATE]
 

--- a/custom_components/myskoda/sensor.py
+++ b/custom_components/myskoda/sensor.py
@@ -180,10 +180,13 @@ class Range(MySkodaSensor):
 
     @property
     def icon(self) -> str:  # noqa: D102
-        if self.vehicle.driving_range.car_type == EngineType.ELECTRIC:
-            return "mdi:ev-station"
-        else:
+        if vehicle.vehicle.driving_range is None or vehicle.vehicle.driving_range.car_type is None:
             return "mdi:gas-station"
+        else:
+            if self.vehicle.driving_range.car_type == EngineType.ELECTRIC:
+                return "mdi:ev-station"
+            else:
+                return "mdi:gas-station"
 
     @property
     def native_value(self) -> int | float | None:  # noqa: D102

--- a/custom_components/myskoda/sensor.py
+++ b/custom_components/myskoda/sensor.py
@@ -180,7 +180,10 @@ class Range(MySkodaSensor):
 
     @property
     def icon(self) -> str:  # noqa: D102
-        if self.vehicle.driving_range is None or self.vehicle.driving_range.car_type is None:
+        if (
+            self.vehicle.driving_range is None
+            or self.vehicle.driving_range.car_type is None
+        ):
             return "mdi:gas-station"
         else:
             if self.vehicle.driving_range.car_type == EngineType.ELECTRIC:


### PR DESCRIPTION
Changed range to use value from driving_range.total_range_in_km instead of a value from charging (so it can be used by all engine types)
