### PR TITLE
Fix aiohttp autocleanup

### DIFF
--- a/custom_components/myskoda/__init__.py
+++ b/custom_components/myskoda/__init__.py
@@ -65,6 +65,13 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
+
+    coordinators = hass.data[DOMAIN][entry.entry_id].get(COORDINATORS)
+    if coordinators:
+        for coord in coordinators:
+            await coord.myskoda.disconnect()
+            await coord.myskoda.session.close()
+
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)

--- a/custom_components/myskoda/__init__.py
+++ b/custom_components/myskoda/__init__.py
@@ -65,13 +65,6 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-
-    coordinators = hass.data[DOMAIN][entry.entry_id].get(COORDINATORS)
-    if coordinators:
-        for coord in coordinators:
-            await coord.myskoda.disconnect()
-            await coord.myskoda.session.close()
-
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)

--- a/custom_components/myskoda/__init__.py
+++ b/custom_components/myskoda/__init__.py
@@ -36,7 +36,9 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry) -> bool:
     if config.options.get("tracing"):
         trace_configs.append(TRACE_CONFIG)
 
-    session = async_create_clientsession(hass, trace_configs=trace_configs)
+    session = async_create_clientsession(
+        hass, trace_configs=trace_configs, auto_cleanup=False
+    )
     myskoda = MySkoda(session, get_default_context())
 
     try:


### PR DESCRIPTION
There appears to be no event in HA that handles unloading an integration, only a `config_entry`, so we only need to keep the session alive.

Fixes skodaconnect/myskoda#185