### PR TITLE
Added auxiliary heater climate entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ If your desired language is not available, please [open an issue](https://github
 - Remaining Charging Time
 - Last Updated
 - Maintenance Interval
+- Oil Service Interval
+- Fuel Level
+- Combustion range
+- Electric range 
 
 ### Binary Sensors
 
@@ -52,10 +56,16 @@ If your desired language is not available, please [open an issue](https://github
 - Window Heating
 - Reduced Current
 - Battery Care Mode
+- Doors
+
+### Buttons
+- Honk and Flash
+- Flash
 
 ### Climate
 
-Air conditioning is exposed as climate.
+- Air conditioning is exposed as climate.
+- Auxiliary heater is exposed as climate.
 
 ### Numbers
 

--- a/custom_components/myskoda/climate.py
+++ b/custom_components/myskoda/climate.py
@@ -143,8 +143,8 @@ class AuxiliaryHeater(MySkodaEntity, ClimateEntity):
     """Auxiliary heater control for MySkoda vehicles."""
 
     entity_description = ClimateEntityDescription(
-        key="auxiliary",
-        translation_key="auxiliary",
+        key="auxiliary_heater",
+        translation_key="auxiliary_heater",
     )
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_supported_features = (

--- a/custom_components/myskoda/climate.py
+++ b/custom_components/myskoda/climate.py
@@ -203,7 +203,8 @@ class AuxiliaryHeater(MySkodaEntity, ClimateEntity):
                 return
 
             if hvac_mode == HVACMode.HEAT:
-                if self.coordinator.config.options.get(CONF_SPIN):
+                spin = self.coordinator.config.options.get(CONF_SPIN)
+                if spin is not None:
                     if (
                         ac.state != AirConditioningState.OFF
                         and ac.state != AirConditioningState.HEATING_AUXILIARY
@@ -214,7 +215,7 @@ class AuxiliaryHeater(MySkodaEntity, ClimateEntity):
                     await self.coordinator.myskoda.start_auxiliary_heating(
                         self.vehicle.info.vin,
                         target_temperature.temperature_value,
-                        spin=self.coordinator.config.options.get(CONF_SPIN),
+                        spin,
                     )
                 else:
                     _LOGGER.error("Cannot start auxiliary heater: No S-PIN set.")

--- a/custom_components/myskoda/climate.py
+++ b/custom_components/myskoda/climate.py
@@ -20,7 +20,7 @@ from homeassistant.util import Throttle
 from myskoda.models.air_conditioning import AirConditioning, AirConditioningState
 from myskoda.models.info import CapabilityId
 
-from .const import API_COOLDOWN_IN_SECONDS, COORDINATORS, DOMAIN
+from .const import API_COOLDOWN_IN_SECONDS, COORDINATORS, DOMAIN, CONF_SPIN
 from .coordinator import MySkodaDataUpdateCoordinator
 from .entity import MySkodaEntity
 from .utils import add_supported_entities
@@ -35,7 +35,7 @@ async def async_setup_entry(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     add_supported_entities(
-        available_entities=[MySkodaClimate],
+        available_entities=[MySkodaClimate, AuxiliaryHeater],
         coordinators=hass.data[DOMAIN][config.entry_id][COORDINATORS],
         async_add_entities=async_add_entities,
     )
@@ -72,7 +72,10 @@ class MySkodaClimate(MySkodaEntity, ClimateEntity):
     @property
     def hvac_mode(self) -> HVACMode | None:  # noqa: D102
         if ac := self._air_conditioning():
-            if ac.state != AirConditioningState.OFF:
+            if (
+                ac.state != AirConditioningState.OFF
+                and ac.state != AirConditioningState.HEATING_AUXILIARY
+            ):
                 return HVACMode.HEAT_COOL
             return HVACMode.OFF
 
@@ -101,6 +104,10 @@ class MySkodaClimate(MySkodaEntity, ClimateEntity):
                 return
 
             if hvac_mode == HVACMode.HEAT_COOL:
+                if ac.state == AirConditioningState.HEATING_AUXILIARY:
+                    await self.coordinator.myskoda.stop_auxiliary_heating(
+                        self.vehicle.info.vin
+                    )
                 await self.coordinator.myskoda.start_air_conditioning(
                     self.vehicle.info.vin,
                     target_temperature.temperature_value,
@@ -123,10 +130,116 @@ class MySkodaClimate(MySkodaEntity, ClimateEntity):
         await self.coordinator.myskoda.set_target_temperature(
             self.vehicle.info.vin, temp
         )
-        _LOGGER.info("AC disabled.")
+        _LOGGER.info("Target temperature for AC set.")
 
     def required_capabilities(self) -> list[CapabilityId]:
         return [
             CapabilityId.AIR_CONDITIONING,
+            CapabilityId.AIR_CONDITIONING_SAVE_AND_ACTIVATE,
+        ]
+
+
+class AuxiliaryHeater(MySkodaEntity, ClimateEntity):
+    """Auxiliary heater control for MySkoda vehicles."""
+
+    entity_description = ClimateEntityDescription(
+        key="auxiliary",
+        translation_key="auxiliary",
+    )
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
+    )
+
+    def __init__(self, coordinator: MySkodaDataUpdateCoordinator, vin: str) -> None:  # noqa: D107
+        super().__init__(
+            coordinator,
+            vin,
+        )
+        ClimateEntity.__init__(self)
+
+    def _air_conditioning(self) -> AirConditioning | None:
+        return self.vehicle.air_conditioning
+
+    @property
+    def available(self) -> bool:
+        if not self.coordinator.config.options.get(CONF_SPIN):
+            return False
+        return True
+
+    @property
+    def hvac_modes(self) -> list[HVACMode]:  # noqa: D102
+        return [HVACMode.HEAT, HVACMode.OFF]
+
+    @property
+    def hvac_mode(self) -> HVACMode | None:  # noqa: D102
+        if ac := self._air_conditioning():
+            if ac.state == AirConditioningState.HEATING_AUXILIARY:
+                return HVACMode.HEAT
+            return HVACMode.OFF
+
+    @property
+    def hvac_action(self) -> HVACAction | None:  # noqa: D102
+        if ac := self._air_conditioning():
+            if ac.state == AirConditioningState.HEATING_AUXILIARY:
+                return HVACAction.HEATING
+            return HVACAction.OFF
+
+    @property
+    def target_temperature(self) -> None | float:  # noqa: D102
+        if ac := self._air_conditioning():
+            target_temperature = ac.target_temperature
+            if target_temperature is None:
+                return
+            return target_temperature.temperature_value
+
+    @Throttle(timedelta(seconds=API_COOLDOWN_IN_SECONDS))
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode):  # noqa: D102
+        if ac := self._air_conditioning():
+            target_temperature = ac.target_temperature
+            if target_temperature is None:
+                return
+
+            if hvac_mode == HVACMode.HEAT:
+                if self.coordinator.config.options.get(CONF_SPIN):
+                    if (
+                        ac.state != AirConditioningState.OFF
+                        and ac.state != AirConditioningState.HEATING_AUXILIARY
+                    ):
+                        await self.coordinator.myskoda.stop_air_conditioning(
+                            self.vehicle.info.vin
+                        )
+                    await self.coordinator.myskoda.start_auxiliary_heating(
+                        self.vehicle.info.vin,
+                        target_temperature.temperature_value,
+                        spin=self.coordinator.config.options.get(CONF_SPIN),
+                    )
+                else:
+                    _LOGGER.error("Cannot start auxiliary heater: No S-PIN set.")
+            else:
+                await self.coordinator.myskoda.stop_auxiliary_heating(
+                    self.vehicle.info.vin
+                )
+            _LOGGER.info("Auxiliary HVAC mode set to %s.", hvac_mode)
+
+    async def async_turn_on(self):  # noqa: D102
+        await self.async_set_hvac_mode(HVACMode.HEAT)
+
+    async def async_turn_off(self):  # noqa: D102
+        await self.async_set_hvac_mode(HVACMode.OFF)
+
+    @Throttle(timedelta(seconds=API_COOLDOWN_IN_SECONDS))
+    async def async_set_temperature(self, **kwargs):  # noqa: D102
+        temp = kwargs[ATTR_TEMPERATURE]
+        await self.coordinator.myskoda.set_target_temperature(
+            self.vehicle.info.vin, temp
+        )
+        _LOGGER.info("Target temperature for auxiliary heater set.")
+
+    def required_capabilities(self) -> list[CapabilityId]:
+        return [
+            CapabilityId.AIR_CONDITIONING_HEATING_SOURCE_AUXILIARY,
             CapabilityId.AIR_CONDITIONING_SAVE_AND_ACTIVATE,
         ]

--- a/custom_components/myskoda/climate.py
+++ b/custom_components/myskoda/climate.py
@@ -105,18 +105,24 @@ class MySkodaClimate(MySkodaEntity, ClimateEntity):
 
             if hvac_mode == HVACMode.HEAT_COOL:
                 if ac.state == AirConditioningState.HEATING_AUXILIARY:
+                    _LOGGER.info(
+                        "Auxiliary heating detected for %s, stopping first.",
+                        self.vehicle.info.vin,
+                    )
                     await self.coordinator.myskoda.stop_auxiliary_heating(
                         self.vehicle.info.vin
                     )
+                _LOGGER.info("Starting Air conditioning for %s.", self.vehicle.info.vin)
                 await self.coordinator.myskoda.start_air_conditioning(
                     self.vehicle.info.vin,
                     target_temperature.temperature_value,
                 )
             else:
+                _LOGGER.info("Stopping Air conditioning for %s.", self.vehicle.info.vin)
                 await self.coordinator.myskoda.stop_air_conditioning(
                     self.vehicle.info.vin
                 )
-            _LOGGER.info("HVAC mode set to %s.", hvac_mode)
+            _LOGGER.info("HVAC mode set to %s for %s.", hvac_mode, self.vin)
 
     async def async_turn_on(self):  # noqa: D102
         await self.async_set_hvac_mode(HVACMode.HEAT_COOL)
@@ -130,7 +136,9 @@ class MySkodaClimate(MySkodaEntity, ClimateEntity):
         await self.coordinator.myskoda.set_target_temperature(
             self.vehicle.info.vin, temp
         )
-        _LOGGER.info("Target temperature for AC set.")
+        _LOGGER.info(
+            "Target temperature for AC set to %s for %s.", temp, self.vehicle.info.vin
+        )
 
     def required_capabilities(self) -> list[CapabilityId]:
         return [
@@ -209,9 +217,16 @@ class AuxiliaryHeater(MySkodaEntity, ClimateEntity):
                         ac.state != AirConditioningState.OFF
                         and ac.state != AirConditioningState.HEATING_AUXILIARY
                     ):
+                        _LOGGER.info(
+                            "Air conditioning detected for %s, stopping first.",
+                            self.vehicle.info.vin,
+                        )
                         await self.coordinator.myskoda.stop_air_conditioning(
                             self.vehicle.info.vin
                         )
+                    _LOGGER.info(
+                        "Starting Auxiliary heating for %s.", self.vehicle.info.vin
+                    )
                     await self.coordinator.myskoda.start_auxiliary_heating(
                         self.vehicle.info.vin,
                         target_temperature.temperature_value,
@@ -220,10 +235,17 @@ class AuxiliaryHeater(MySkodaEntity, ClimateEntity):
                 else:
                     _LOGGER.error("Cannot start auxiliary heater: No S-PIN set.")
             else:
+                _LOGGER.info(
+                    "Stopping Auxiliary heating for %s.", self.vehicle.info.vin
+                )
                 await self.coordinator.myskoda.stop_auxiliary_heating(
                     self.vehicle.info.vin
                 )
-            _LOGGER.info("Auxiliary HVAC mode set to %s.", hvac_mode)
+            _LOGGER.info(
+                "Auxiliary HVAC mode set to %s for %s.",
+                hvac_mode,
+                self.vehicle.info.vin,
+            )
 
     async def async_turn_on(self):  # noqa: D102
         await self.async_set_hvac_mode(HVACMode.HEAT)
@@ -237,7 +259,11 @@ class AuxiliaryHeater(MySkodaEntity, ClimateEntity):
         await self.coordinator.myskoda.set_target_temperature(
             self.vehicle.info.vin, temp
         )
-        _LOGGER.info("Target temperature for auxiliary heater set.")
+        _LOGGER.info(
+            "Target temperature for auxiliary heater set to %s for %s.",
+            temp,
+            self.vehicle.info.vin,
+        )
 
     def required_capabilities(self) -> list[CapabilityId]:
         return [

--- a/custom_components/myskoda/climate.py
+++ b/custom_components/myskoda/climate.py
@@ -105,24 +105,21 @@ class MySkodaClimate(MySkodaEntity, ClimateEntity):
 
             if hvac_mode == HVACMode.HEAT_COOL:
                 if ac.state == AirConditioningState.HEATING_AUXILIARY:
-                    _LOGGER.info(
-                        "Auxiliary heating detected for %s, stopping first.",
-                        self.vehicle.info.vin,
-                    )
+                    _LOGGER.info("Auxiliary heating detected, stopping first.")
                     await self.coordinator.myskoda.stop_auxiliary_heating(
                         self.vehicle.info.vin
                     )
-                _LOGGER.info("Starting Air conditioning for %s.", self.vehicle.info.vin)
+                _LOGGER.info("Starting Air conditioning.")
                 await self.coordinator.myskoda.start_air_conditioning(
                     self.vehicle.info.vin,
                     target_temperature.temperature_value,
                 )
             else:
-                _LOGGER.info("Stopping Air conditioning for %s.", self.vehicle.info.vin)
+                _LOGGER.info("Stopping Air conditioning.")
                 await self.coordinator.myskoda.stop_air_conditioning(
                     self.vehicle.info.vin
                 )
-            _LOGGER.info("HVAC mode set to %s for %s.", hvac_mode, self.vin)
+            _LOGGER.info("HVAC mode set to %s.", hvac_mode)
 
     async def async_turn_on(self):  # noqa: D102
         await self.async_set_hvac_mode(HVACMode.HEAT_COOL)
@@ -136,9 +133,7 @@ class MySkodaClimate(MySkodaEntity, ClimateEntity):
         await self.coordinator.myskoda.set_target_temperature(
             self.vehicle.info.vin, temp
         )
-        _LOGGER.info(
-            "Target temperature for AC set to %s for %s.", temp, self.vehicle.info.vin
-        )
+        _LOGGER.info("Target temperature for AC set to %s.", temp)
 
     def required_capabilities(self) -> list[CapabilityId]:
         return [
@@ -217,16 +212,11 @@ class AuxiliaryHeater(MySkodaEntity, ClimateEntity):
                         ac.state != AirConditioningState.OFF
                         and ac.state != AirConditioningState.HEATING_AUXILIARY
                     ):
-                        _LOGGER.info(
-                            "Air conditioning detected for %s, stopping first.",
-                            self.vehicle.info.vin,
-                        )
+                        _LOGGER.info("Air conditioning detected, stopping first.")
                         await self.coordinator.myskoda.stop_air_conditioning(
                             self.vehicle.info.vin
                         )
-                    _LOGGER.info(
-                        "Starting Auxiliary heating for %s.", self.vehicle.info.vin
-                    )
+                    _LOGGER.info("Starting Auxiliary heating.")
                     await self.coordinator.myskoda.start_auxiliary_heating(
                         self.vehicle.info.vin,
                         target_temperature.temperature_value,
@@ -235,17 +225,11 @@ class AuxiliaryHeater(MySkodaEntity, ClimateEntity):
                 else:
                     _LOGGER.error("Cannot start auxiliary heater: No S-PIN set.")
             else:
-                _LOGGER.info(
-                    "Stopping Auxiliary heating for %s.", self.vehicle.info.vin
-                )
+                _LOGGER.info("Stopping Auxiliary heating.")
                 await self.coordinator.myskoda.stop_auxiliary_heating(
                     self.vehicle.info.vin
                 )
-            _LOGGER.info(
-                "Auxiliary HVAC mode set to %s for %s.",
-                hvac_mode,
-                self.vehicle.info.vin,
-            )
+            _LOGGER.info("Auxiliary HVAC mode set to %s.", hvac_mode)
 
     async def async_turn_on(self):  # noqa: D102
         await self.async_set_hvac_mode(HVACMode.HEAT)
@@ -259,11 +243,7 @@ class AuxiliaryHeater(MySkodaEntity, ClimateEntity):
         await self.coordinator.myskoda.set_target_temperature(
             self.vehicle.info.vin, temp
         )
-        _LOGGER.info(
-            "Target temperature for auxiliary heater set to %s for %s.",
-            temp,
-            self.vehicle.info.vin,
-        )
+        _LOGGER.info("Target temperature for auxiliary heater set to %s.", temp)
 
     def required_capabilities(self) -> list[CapabilityId]:
         return [

--- a/custom_components/myskoda/coordinator.py
+++ b/custom_components/myskoda/coordinator.py
@@ -134,6 +134,8 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
             OperationName.SET_AIR_CONDITIONING_TARGET_TEMPERATURE,
             OperationName.START_WINDOW_HEATING,
             OperationName.STOP_WINDOW_HEATING,
+            OperationName.START_AUXILIARY_HEATING,
+            OperationName.STOP_AUXILIARY_HEATING,
         ]:
             await self.update_air_conditioning()
         if event.operation.operation in [

--- a/custom_components/myskoda/icons.json
+++ b/custom_components/myskoda/icons.json
@@ -47,6 +47,9 @@
 		"climate": {
 			"climate": {
 				"default": "mdi:air-conditioner"
+			},
+			"auxiliary": {
+				"default": "mdi:radiator"
 			}
 		},
 		"device_tracker": {

--- a/custom_components/myskoda/icons.json
+++ b/custom_components/myskoda/icons.json
@@ -48,7 +48,7 @@
 			"climate": {
 				"default": "mdi:air-conditioner"
 			},
-			"auxiliary": {
+			"auxiliary_heater": {
 				"default": "mdi:radiator"
 			}
 		},

--- a/custom_components/myskoda/translations/en.json
+++ b/custom_components/myskoda/translations/en.json
@@ -94,7 +94,7 @@
             "climate": {
                 "name": "Air Conditioning"
             },
-            "auxiliary": {
+            "auxiliary_heater": {
                 "name": "Auxiliary Heater"
             }
         },

--- a/custom_components/myskoda/translations/en.json
+++ b/custom_components/myskoda/translations/en.json
@@ -93,6 +93,9 @@
         "climate": {
             "climate": {
                 "name": "Air Conditioning"
+            },
+            "auxiliary": {
+                "name": "Auxiliary Heater"
             }
         },
         "device_tracker": {


### PR DESCRIPTION
Auxiliary heater added as separate climate entity.
When started, and AC already running, AC must be switched off first. The same is valid for AC - when started and Auxiliary heater already running, auxiliary heater must be switched off first. If not, car will not change heater source