### PR TITLE
Fix climate feature error.

### DIFF
--- a/custom_components/myskoda/climate.py
+++ b/custom_components/myskoda/climate.py
@@ -55,6 +55,11 @@ class MySkodaClimate(MySkodaEntity, ClimateEntity):
         translation_key="climate",
     )
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
+    )
 
     def __init__(self, coordinator: MySkodaDataUpdateCoordinator, vin: str) -> None:  # noqa: D107
         super().__init__(
@@ -62,12 +67,6 @@ class MySkodaClimate(MySkodaEntity, ClimateEntity):
             vin,
         )
         ClimateEntity.__init__(self)
-        if self.is_supported():
-            _attr_supported_features = (
-                ClimateEntityFeature.TARGET_TEMPERATURE
-                | ClimateEntityFeature.TURN_ON
-                | ClimateEntityFeature.TURN_OFF
-            )
 
     def _air_conditioning(self) -> AirConditioning | None:
         return self.vehicle.air_conditioning


### PR DESCRIPTION
Found during testing v1.11.0 locally.
Apparently this does not work when setting flags upon initialisation, gives following errors and renders AC entity functionally broken:

```024-11-26 11:24:41.766 INFO (MainThread) [homeassistant.components.climate] Setting up myskoda.climate
2024-11-26 11:24:41.766 WARNING (MainThread) [homeassistant.components.climate] Entity None (<class 'custom_components.myskoda.climate.MySkodaClimate'>) does not set ClimateEntityFeature.TURN_OFF but implements the turn_off method. Please create a bug report at https://github.com/skodaconnect/homeassistant-myskoda/issues
2024-11-26 11:24:41.767 WARNING (MainThread) [homeassistant.components.climate] Entity None (<class 'custom_components.myskoda.climate.MySkodaClimate'>) does not set ClimateEntityFeature.TURN_ON but implements the turn_on method. Please create a bug report at https://github.com/skodaconnect/homeassistant-myskoda/issues
2024-11-26 11:24:41.767 WARNING (MainThread) [homeassistant.components.climate] Entity None (<class 'custom_components.myskoda.climate.MySkodaClimate'>) implements HVACMode(s): heat_cool, off and therefore implicitly supports the turn_on/turn_off methods without setting the proper ClimateEntityFeature. Please create a bug report at https://github.com/skodaconnect/homeassistant-myskoda/issues
```