### PR TITLE
AC changed to use only AIR_CONDITIONING capability 

### DIFF
--- a/custom_components/myskoda/climate.py
+++ b/custom_components/myskoda/climate.py
@@ -147,10 +147,7 @@ class MySkodaClimate(MySkodaEntity, ClimateEntity):
         _LOGGER.info("Target temperature for AC set to %s.", temp)
 
     def required_capabilities(self) -> list[CapabilityId]:
-        return [
-            CapabilityId.AIR_CONDITIONING,
-            CapabilityId.AIR_CONDITIONING_SAVE_AND_ACTIVATE,
-        ]
+        return [CapabilityId.AIR_CONDITIONING]
 
     def is_supported(self) -> bool:
         all_capabilities_present = all(


### PR DESCRIPTION
should be sufficient because Citigo iV doesnt have the other capability (AIR_CONDITIONING_SAVE_AND_ACTIVATE) but still can enable/disable AC from myskoda app