### PR TITLE
Disable packaging via poetry. 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
     "Fabrice Devaux <fabrice.devaux@gmail.com>",
 ]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "~3.12,<3.13"


### PR DESCRIPTION
Disable packaging via poetry. 
We add the package as zip to the release for use with HACS instead.