### PR TITLE
Change default debounce behavior

### DIFF
--- a/custom_components/myskoda/coordinator.py
+++ b/custom_components/myskoda/coordinator.py
@@ -317,7 +317,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
             self.set_updated_vehicle(vehicle)
 
     def _debounce(
-        self, func: RefreshFunction, immediate: bool = False
+        self, func: RefreshFunction, immediate: bool = True
     ) -> RefreshFunction:
         return MySkodaDebouncer(self.hass, func, immediate).async_call
 


### PR DESCRIPTION
Many remarks about this integration include a "sluggish feel". 
The main reason for this, is that we use a so-called debouncer, to make sure that we do not poll the API to often, causing a lock-out (error 429)

Currently the default behaviour is:

-- Event happens
-- Debouncer is initiated and waits a default of 30s
-- Update is polled
-- Event happens
-- <etc>

This changes the default behaviour to:

-- Event happens
-- Debouncer is initiated and polls an update
-- All subsequent events of the same type are ignored for a default of 30s
-- Event happens
-- <etc>

This should make the integration feel less sluggish, at the risk of polling too early.