### PR TITLE
Disable MQTT connection during password check

### DIFF
--- a/custom_components/myskoda/config_flow.py
+++ b/custom_components/myskoda/config_flow.py
@@ -58,9 +58,12 @@ async def validate_options_input(
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> None:
     """Check that the inputs are valid."""
-    hub = MySkoda(async_get_clientsession(hass), get_default_context())
+    hub = MySkoda(
+        async_get_clientsession(hass), get_default_context(), mqtt_enabled=False
+    )
 
     await hub.connect(data["email"], data["password"])
+    await hub.disconnect()
 
 
 STEP_USER_DATA_SCHEMA = vol.Schema(


### PR DESCRIPTION
By default MQTT is connected during the config flow when we check if your password is valid.
This is unneeded and causes many listeners for MQTT changes, making mqtt messages get processed multiple times.

Not only is this unneeded and clutters the logfiles, it also can cause more API calls than needed and slow down HA

Also, we keep this extra connection around, with no clear purpose. So let's clean it up.