### PR TITLE
show HVACMode.FAN_ONLY also for AUXILIARY_HEATING_BASIC

### DIFF
--- a/custom_components/myskoda/climate.py
+++ b/custom_components/myskoda/climate.py
@@ -239,7 +239,9 @@ class AuxiliaryHeater(MySkodaEntity, ClimateEntity):
     def _start_mode(self) -> AuxiliaryStartMode | None:
         """Return start mode for auxiliary heater."""
         if self.has_all_capabilities(
-            [CapabilityId.AUXILIARY_HEATING, CapabilityId.ACTIVE_VENTILATION]
+            [CapabilityId.AUXILIARY_HEATING]
+        ) and self.has_any_capability(
+            [CapabilityId.ACTIVE_VENTILATION, CapabilityId.AUXILIARY_HEATING_BASIC]
         ):
             return AuxiliaryStartMode.HEATING
 
@@ -276,7 +278,9 @@ class AuxiliaryHeater(MySkodaEntity, ClimateEntity):
     @property
     def hvac_modes(self) -> list[HVACMode]:  # noqa: D102
         modes = [HVACMode.HEAT, HVACMode.OFF]
-        if self.has_all_capabilities([CapabilityId.ACTIVE_VENTILATION]):
+        if self.has_any_capability(
+            [CapabilityId.ACTIVE_VENTILATION, CapabilityId.AUXILIARY_HEATING_BASIC]
+        ):
             modes.append(HVACMode.FAN_ONLY)
         return modes
 


### PR DESCRIPTION
From last few fixtures its seems like skoda changed `ACTIVE_VENTILATION` to `AUXILIARY_HEATING_BASIC`. Because of that ventilation was not available in AuxiliaryHeater entity. As I'm not sure if Skoda replaced that capability for all or only for some cars, I have modified the code to checks for both capabilities.