### PR TITLE
Fix OutsideTemperature sensor setup

### DIFF
--- a/custom_components/myskoda/sensor.py
+++ b/custom_components/myskoda/sensor.py
@@ -59,6 +59,7 @@ async def async_setup_entry(
             OilServiceIntervalDays,
             OilServiceIntervalKM,
             Operation,
+            OutsideTemperature,
             Range,
             RemainingChargingTime,
             SoftwareVersion,


### PR DESCRIPTION
Adds the OutsideTemperature (created in https://github.com/skodaconnect/homeassistant-myskoda/pull/388) as a HA sensor