### PR TITLE
Prevent integration from stalling when MQTT does not connect

### DIFF
--- a/custom_components/myskoda/__init__.py
+++ b/custom_components/myskoda/__init__.py
@@ -54,7 +54,7 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry) -> bool:
     session = async_create_clientsession(
         hass, trace_configs=trace_configs, auto_cleanup=False
     )
-    myskoda = MySkoda(session, get_default_context())
+    myskoda = MySkoda(session, get_default_context(), mqtt_enabled=False)
 
     try:
         await myskoda.connect(config.data["email"], config.data["password"])

--- a/custom_components/myskoda/coordinator.py
+++ b/custom_components/myskoda/coordinator.py
@@ -8,7 +8,7 @@ from typing import Callable
 
 from aiohttp import ClientError
 from aiohttp.client_exceptions import ClientResponseError
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -119,7 +119,10 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
         user = None
         config = self.data.config if self.data and self.data.config else Config()
 
-        if not self.myskoda.mqtt:
+        if (
+            not self.myskoda.mqtt
+            and self.config_entry.state is not ConfigEntryState.SETUP_IN_PROGRESS
+        ):
             _LOGGER.debug("MQTT is not set up yet. Connecting now.")
             await self.myskoda.enable_mqtt()
             self.myskoda.subscribe(self._on_mqtt_event)

--- a/custom_components/myskoda/coordinator.py
+++ b/custom_components/myskoda/coordinator.py
@@ -114,12 +114,15 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
         self.update_vehicle = self._debounce(self._update_vehicle)
         self.update_positions = self._debounce(self._update_positions)
 
-        myskoda.subscribe(self._on_mqtt_event)
-
     async def _async_update_data(self) -> State:
         vehicle = None
         user = None
         config = self.data.config if self.data and self.data.config else Config()
+
+        if not self.myskoda.mqtt:
+            _LOGGER.debug("MQTT is not set up yet. Connecting now.")
+            await self.myskoda.enable_mqtt()
+            self.myskoda.subscribe(self._on_mqtt_event)
 
         _LOGGER.debug("Performing scheduled update of all data for vin %s", self.vin)
         try:


### PR DESCRIPTION
In a service disruption we have seen MQTT become unavailable.
Since we by default await the presence of the MQTT service, this blocks the integration from starting.

This PR changes behaviour in a subtle manner:
- The integration will initialise with only polling present
- As soon as regular updates are scheduled, we enable MQTT listening as well