### PR TITLE
add download diagnostics feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,21 @@ When pressed, the button triggers the fixture generation process, and the genera
 
 This feature simplifies the process of creating fixtures by providing a user-friendly interface for initiating the operation.
 
+## Diagnostics
+
+In addition to **Generate Fixtures feature** which generates the vehicle fixtures into Home Assitant Core log, the **Diagnostics** feature allows you to directly download diagnostic data for sharing in issue reports. Providing diagnostics data when reporting an issue helps developers diagnose and resolve your problem more efficiently.
+
+You can download the diagnostics data as a text file from the device page or the integrations dashboard.
+
+Diagnostics file include:
+
+- Home Assistant version and details
+- List of installed components and their versions
+- MySkoda integration version and details
+- Anonymized vehicle fixtures from the MySkoda API. (fixtures can be found under the `data` key in the diagnostics response)
+
+> **Note:** Vehicle fixtures are responses from all available MySkoda API endpoints always returned in both raw and serialized format.
+
 ## Disclaimer
 
 This Homeassistant integration uses an unofficial API client for the Skoda API and is not affiliated with, endorsed by, or associated with Skoda Auto or any of its subsidiaries.

--- a/custom_components/myskoda/diagnostics.py
+++ b/custom_components/myskoda/diagnostics.py
@@ -1,0 +1,63 @@
+"""Diagnostics support for MySkoda integration."""
+
+import logging
+import json
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.device_registry import DeviceEntry
+from myskoda.models.fixtures import Endpoint
+from typing import Any
+
+
+from .const import DOMAIN, COORDINATORS
+from .coordinator import MySkodaDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_get_device_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry, device: DeviceEntry
+) -> dict[str, Any]:
+    """Return diagnostics for selected vehicle."""
+    if not (vin := device.serial_number):
+        error_message = "No VIN found for this device"
+        _LOGGER.error(error_message)
+        return {
+            "error": error_message,
+        }
+
+    coordinator: MySkodaDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ][COORDINATORS][vin]
+
+    if not coordinator:
+        error_message = f"No coordinator found for VIN: {vin}"
+        _LOGGER.error(error_message)
+        return {
+            "error": error_message,
+        }
+
+    try:
+        # Fetch diagnostics data from the MySkoda API
+        specs = coordinator.data.vehicle.info.specification
+        description = (
+            f"Fixtures for {specs.model} {specs.trim_level} {specs.model_year}"
+        )
+
+        result = await coordinator.myskoda.generate_get_fixture(
+            coordinator.data.vehicle.info.specification.model,
+            description,
+            [vin],
+            Endpoint.ALL,
+        )
+
+        return {
+            "fixtures": json.loads(result.to_json()),
+        }
+
+    except Exception as e:
+        error_message = f"Error generating fixtures for VIN {vin}: {e}"
+        _LOGGER.error(error_message)
+        return {
+            "error": error_message,
+        }


### PR DESCRIPTION
fixtures can be downloaded directly using `DOWNLOAD DIAGNOSTICS` button from the device page. They will be returned in data object as this is the way how its implemented by HA. There are some other data but nothing private. Tried to return also yaml but no matter what I tried, formatting was always broken as its returned in dictionary. 

And probably we can remove `Generate Fixtures` button what do you think?