### PR TITLE
CitigoE iV partial update

### DIFF
--- a/custom_components/myskoda/coordinator.py
+++ b/custom_components/myskoda/coordinator.py
@@ -125,7 +125,27 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
 
         _LOGGER.debug("Performing scheduled update of all data for vin %s", self.vin)
         try:
-            vehicle = await self.myskoda.get_vehicle(self.vin)
+            if (
+                self.data.vehicle.info.device_platform == "MBB"
+                and self.data.vehicle.info.specification.model == "CitigoE iV"
+            ):
+                _LOGGER.debug(
+                    "Detected CitigoE iV, requesting only partial update without health"
+                )
+                vehicle = await self.myskoda.get_partial_vehicle(
+                    self.vin,
+                    [
+                        CapabilityId.AIR_CONDITIONING,
+                        CapabilityId.AUXILIARY_HEATING,
+                        CapabilityId.CHARGING,
+                        CapabilityId.PARKING_POSITION,
+                        CapabilityId.STATE,
+                        CapabilityId.TRIP_STATISTICS,
+                        CapabilityId.VEHICLE_HEALTH_INSPECTION,
+                    ],
+                )
+            else:
+                vehicle = await self.myskoda.get_vehicle(self.vin)
             user = await self.myskoda.get_user()
         except ClientResponseError as err:
             handle_aiohttp_error("user and vehicle", err, self.hass, self.config)

--- a/custom_components/myskoda/coordinator.py
+++ b/custom_components/myskoda/coordinator.py
@@ -141,7 +141,6 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
                         CapabilityId.PARKING_POSITION,
                         CapabilityId.STATE,
                         CapabilityId.TRIP_STATISTICS,
-                        CapabilityId.VEHICLE_HEALTH_INSPECTION,
                     ],
                 )
             else:


### PR DESCRIPTION
Hardcode a different update method for CitigoE as we learn how to cope with the limitations of this model.

This is expected to change over time, as we get more experience with this car model's behaviour. This model seems to dislike our polling of the vehicle health details very much, causing many errors in app and integration.

Fixes #212 