### PR TITLE
Deprecate fixtures button

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If your desired language is not available, please [open an issue](https://github
 ### Buttons
 - Honk and Flash
 - Flash
-- Generate Fixtures
+- Generate Fixtures (deprecated, use Device Diagnostics instead)
 
 ### Climate
 

--- a/custom_components/myskoda/button.py
+++ b/custom_components/myskoda/button.py
@@ -91,13 +91,20 @@ class Flash(MySkodaButton):
 
 
 class GenerateFixtures(MySkodaButton):
-    """Generate Fixtures."""
+    """Generate Fixtures.
+    This entity is deprecated and disabled by default, scheduled to be removed in v2.0.0
+
+    The functionality is implemented in the 'Diagnostics' function for the HA device,
+    which is where it should be.
+    """
 
     entity_description = ButtonEntityDescription(
         key="generate_fixtures",
         translation_key="generate_fixtures",
         device_class=ButtonDeviceClass.IDENTIFY,
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        entity_registry_visible_default=False,
     )
 
     def __init__(


### PR DESCRIPTION
Deprecate the fixtures button, since the functionality is in the Device Diagnostics now.

Schedule this for removal whenever we release v2.0.0