### PR TITLE
Handle marketing consent error in integration

### DIFF
--- a/custom_components/myskoda/__init__.py
+++ b/custom_components/myskoda/__init__.py
@@ -17,7 +17,11 @@ from myskoda import (
     AuthorizationFailedError,
 )
 from myskoda.myskoda import TRACE_CONFIG
-from myskoda.auth.authorization import CSRFError, TermsAndConditionsError
+from myskoda.auth.authorization import (
+    CSRFError,
+    TermsAndConditionsError,
+    MarketingConsentError,
+)
 
 
 from .const import COORDINATORS, DOMAIN
@@ -61,9 +65,9 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry) -> bool:
     except AuthorizationFailedError as exc:
         _LOGGER.debug("Authorization with MySkoda failed.")
         raise ConfigEntryAuthFailed from exc
-    except TermsAndConditionsError as exc:
+    except (TermsAndConditionsError, MarketingConsentError) as exc:
         _LOGGER.error(
-            "New terms and conditions detected while logging in. Please log into the MySkoda app (may require a logout first) to access the new Terms and Conditions. This HomeAssistant integration currently can not continue."
+            "Change to terms and conditions or consents detected while logging in. Please log into the MySkoda app (may require a logout first) to access the new Terms and Conditions. This HomeAssistant integration currently can not continue."
         )
         async_create_tnc_issue(hass, config.entry_id)
         raise ConfigEntryNotReady from exc

--- a/custom_components/myskoda/translations/en.json
+++ b/custom_components/myskoda/translations/en.json
@@ -251,8 +251,8 @@
     },
     "issues": {
         "new_tandc": {
-            "title": "Review new Terms and Conditions for MySkoda",
-            "description": "Detected login failure due to missing acceptance of Terms and Conditions.\n\nSkoda may have issued new Terms and Conditions.\n\nPlease log out and back in of the MySkoda app to review them.\nThis integration cannot continue without accepted Terms and Conditions."
+            "title": "Review new consents and T/C for MySkoda",
+            "description": "Detected login failure due to missing acceptance of Terms and Conditions or consents.\n\nSkoda may have issued new Terms and Conditions or requires new consents.\n\nPlease log out and back in of the MySkoda app to review them.\nThis integration cannot continue right now."
         },
         "spin_error": {
             "title": "Incorrect S-PIN detected",


### PR DESCRIPTION
This adds integration handling for the new `MarketingConsentError` introduced in myskoda v0.15.4