### PR TITLE
fix for fix missing main render

### DIFF
--- a/custom_components/myskoda/device_tracker.py
+++ b/custom_components/myskoda/device_tracker.py
@@ -100,14 +100,16 @@ class DeviceTracker(MySkodaEntity, TrackerEntity):
                         attributes["entity_picture"] = render["exterior_front"]
                         break
         else:
-            _LOGGER.debug("'unmodified_exterior_front' not found, falling back to 'unmodified_exterior_side'.")
+            _LOGGER.debug(
+                "'unmodified_exterior_front' not found, falling back to 'unmodified_exterior_side'."
+            )
             render_list = self.get_composite_renders().get("unmodified_exterior_side")
             if isinstance(render_list, list) and render_list:
                 for render in render_list:
                     if isinstance(render, dict) and "exterior_side" in render:
                         attributes["entity_picture"] = render["exterior_side"]
                         break
-        
+
         return attributes
 
     @property

--- a/custom_components/myskoda/device_tracker.py
+++ b/custom_components/myskoda/device_tracker.py
@@ -91,7 +91,7 @@ class DeviceTracker(MySkodaEntity, TrackerEntity):
 
         if render := self.get_renders().get("main"):
             attributes["entity_picture"] = render
-        else:
+        elif render := self.get_composite_renders().get("unmodified_exterior_front"):
             _LOGGER.debug("Main render not found, choosing composite render instead.")
             render_list = self.get_composite_renders().get("unmodified_exterior_front")
             if isinstance(render_list, list) and render_list:
@@ -99,7 +99,15 @@ class DeviceTracker(MySkodaEntity, TrackerEntity):
                     if isinstance(render, dict) and "exterior_front" in render:
                         attributes["entity_picture"] = render["exterior_front"]
                         break
-
+        else:
+            _LOGGER.debug("'unmodified_exterior_front' not found, falling back to 'unmodified_exterior_side'.")
+            render_list = self.get_composite_renders().get("unmodified_exterior_side")
+            if isinstance(render_list, list) and render_list:
+                for render in render_list:
+                    if isinstance(render, dict) and "exterior_side" in render:
+                        attributes["entity_picture"] = render["exterior_side"]
+                        break
+        
         return attributes
 
     @property

--- a/custom_components/myskoda/image.py
+++ b/custom_components/myskoda/image.py
@@ -72,7 +72,7 @@ class MainRenderImage(MySkodaImage):
     def image_url(self) -> str | None:
         if render := self.get_renders().get("main"):
             return render
-        else:
+        elif render := self.get_composite_renders().get("unmodified_exterior_front"):
             _LOGGER.debug("Main render not found, choosing composite render instead.")
             render_list = self.get_composite_renders().get("unmodified_exterior_front")
             if isinstance(render_list, list) and render_list:
@@ -80,6 +80,14 @@ class MainRenderImage(MySkodaImage):
                     if isinstance(render, dict) and "exterior_front" in render:
                         return render["exterior_front"]
 
+        else:
+            _LOGGER.debug("'unmodified_exterior_front' not found, falling back to 'unmodified_exterior_side'.")
+            render_list = self.get_composite_renders().get("unmodified_exterior_side")
+            if isinstance(render_list, list) and render_list:
+                for render in render_list:
+                    if isinstance(render, dict) and "exterior_side" in render:
+                        return render["exterior_side"]
+    
     @property
     def extra_state_attributes(self) -> dict:
         """Return extra state attributes."""

--- a/custom_components/myskoda/image.py
+++ b/custom_components/myskoda/image.py
@@ -81,13 +81,15 @@ class MainRenderImage(MySkodaImage):
                         return render["exterior_front"]
 
         else:
-            _LOGGER.debug("'unmodified_exterior_front' not found, falling back to 'unmodified_exterior_side'.")
+            _LOGGER.debug(
+                "'unmodified_exterior_front' not found, falling back to 'unmodified_exterior_side'."
+            )
             render_list = self.get_composite_renders().get("unmodified_exterior_side")
             if isinstance(render_list, list) and render_list:
                 for render in render_list:
                     if isinstance(render, dict) and "exterior_side" in render:
                         return render["exterior_side"]
-    
+
     @property
     def extra_state_attributes(self) -> dict:
         """Return extra state attributes."""


### PR DESCRIPTION
With pr  #456 the main image render is replaced with exterior_front if unavailable.
Problem is that exterior_front is not available for all vehicles.

If exterior_front is unavailable now exterior_side is used