### PR TITLE
remove AuxiliaryHeating from partial update for CitigoE IV

### DIFF
--- a/custom_components/myskoda/coordinator.py
+++ b/custom_components/myskoda/coordinator.py
@@ -153,7 +153,6 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
                         self.vin,
                         [
                             CapabilityId.AIR_CONDITIONING,
-                            CapabilityId.AUXILIARY_HEATING,
                             CapabilityId.CHARGING,
                             CapabilityId.PARKING_POSITION,
                             CapabilityId.STATE,


### PR DESCRIPTION
CitigoE IV doesnt have auxiliary heater as that's available only for ICE and PHEV vehicles