### PR TITLE
(chore) Reference ConfigEntry consistently

### DIFF
--- a/custom_components/myskoda/button.py
+++ b/custom_components/myskoda/button.py
@@ -54,7 +54,7 @@ class MySkodaButton(MySkodaEntity, ButtonEntity):
         all_capabilities_present = all(
             self.vehicle.has_capability(cap) for cap in self.required_capabilities()
         )
-        readonly = self.coordinator.config.options.get(CONF_READONLY)
+        readonly = self.coordinator.entry.options.get(CONF_READONLY)
 
         return all_capabilities_present and not readonly
 

--- a/custom_components/myskoda/climate.py
+++ b/custom_components/myskoda/climate.py
@@ -48,13 +48,13 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigEntry,
+    entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     add_supported_entities(
         available_entities=[MySkodaClimate, AuxiliaryHeater],
-        coordinators=hass.data[DOMAIN][config.entry_id][COORDINATORS],
+        coordinators=hass.data[DOMAIN][entry.entry_id][COORDINATORS],
         async_add_entities=async_add_entities,
     )
 
@@ -190,7 +190,7 @@ class MySkodaClimate(MySkodaEntity, ClimateEntity):
         all_capabilities_present = all(
             self.vehicle.has_capability(cap) for cap in self.required_capabilities()
         )
-        readonly = self.coordinator.config.options.get(CONF_READONLY)
+        readonly = self.coordinator.entry.options.get(CONF_READONLY)
 
         return all_capabilities_present and not readonly
 
@@ -287,7 +287,7 @@ class AuxiliaryHeater(MySkodaEntity, ClimateEntity):
 
     @property
     def available(self) -> bool:  # noqa: D102
-        if not self.coordinator.config.options.get(CONF_SPIN):
+        if not self.coordinator.entry.options.get(CONF_SPIN):
             return False
         return True
 
@@ -357,7 +357,7 @@ class AuxiliaryHeater(MySkodaEntity, ClimateEntity):
                     start_mode=start_mode,
                     **kwargs,
                 )
-                spin = self.coordinator.config.options.get(CONF_SPIN)
+                spin = self.coordinator.entry.options.get(CONF_SPIN)
                 if spin is None:
                     _LOGGER.error("Cannot start %s: No S-PIN set.", desired_state)
                     return

--- a/custom_components/myskoda/coordinator.py
+++ b/custom_components/myskoda/coordinator.py
@@ -157,14 +157,14 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
         config = self.data.config if self.data and self.data.config else Config()
         operations = self.operations
 
-        if self.config.state == ConfigEntryState.SETUP_IN_PROGRESS:
+        if self.entry.state == ConfigEntryState.SETUP_IN_PROGRESS:
             _LOGGER.debug("Performing initial data fetch for vin %s", self.vin)
             try:
                 user = await self.myskoda.get_user()
                 vehicle = await self._async_get_minimal_data()
             except ClientResponseError as err:
                 handle_aiohttp_error(
-                    "setup user and vehicle", err, self.hass, self.config
+                    "setup user and vehicle", err, self.hass, self.entry
                 )
                 raise UpdateFailed("Failed to retrieve initial data during setup")
 
@@ -186,7 +186,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
 
             async_at_started(
                 hass=self.hass,
-                at_start_cb=_async_finish_startup(self.hass, self.config, self.vin),  # pyright: ignore[reportArgumentType]
+                at_start_cb=_async_finish_startup(self.hass, self.entry, self.vin),  # pyright: ignore[reportArgumentType]
             )  # Schedule post-setup tasks
             return State(vehicle, user, config, operations)
 

--- a/custom_components/myskoda/coordinator.py
+++ b/custom_components/myskoda/coordinator.py
@@ -90,7 +90,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
     data: State
 
     def __init__(
-        self, hass: HomeAssistant, config: ConfigEntry, myskoda: MySkoda, vin: str
+        self, hass: HomeAssistant, entry: ConfigEntry, myskoda: MySkoda, vin: str
     ) -> None:
         """Create a new coordinator."""
 
@@ -99,7 +99,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
             _LOGGER,
             name=DOMAIN,
             update_interval=timedelta(
-                minutes=config.options.get(
+                minutes=entry.options.get(
                     CONF_POLL_INTERVAL, DEFAULT_FETCH_INTERVAL_IN_MINUTES
                 )
             ),
@@ -109,7 +109,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
         self.vin: str = vin
         self.myskoda: MySkoda = myskoda
         self.operations: OrderedDict = OrderedDict()
-        self.config: ConfigEntry = config
+        self.entry: ConfigEntry = entry
         self.update_driving_range = self._debounce(self._update_driving_range)
         self.update_charging = self._debounce(self._update_charging)
         self.update_air_conditioning = self._debounce(self._update_air_conditioning)
@@ -134,7 +134,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
         try:
             user = await self.myskoda.get_user()
         except ClientResponseError as err:
-            handle_aiohttp_error("user", err, self.hass, self.config)
+            handle_aiohttp_error("user", err, self.hass, self.entry)
             if self.data.user:
                 user = self.data.user
             else:
@@ -165,7 +165,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
             else:
                 vehicle = await self.myskoda.get_vehicle(self.vin)
         except ClientResponseError as err:
-            handle_aiohttp_error("vehicle", err, self.hass, self.config)
+            handle_aiohttp_error("vehicle", err, self.hass, self.entry)
         except ClientError as err:
             raise UpdateFailed("Error getting update from MySkoda API: %s", err)
 
@@ -302,7 +302,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
         try:
             driving_range = await self.myskoda.get_driving_range(self.vin)
         except ClientResponseError as err:
-            handle_aiohttp_error("driving range", err, self.hass, self.config)
+            handle_aiohttp_error("driving range", err, self.hass, self.entry)
         except ClientError as err:
             raise UpdateFailed("Error getting update from MySkoda API: %s", err)
 
@@ -318,7 +318,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
         try:
             charging = await self.myskoda.get_charging(self.vin)
         except ClientResponseError as err:
-            handle_aiohttp_error("charging information", err, self.hass, self.config)
+            handle_aiohttp_error("charging information", err, self.hass, self.entry)
         except ClientError as err:
             raise UpdateFailed("Error getting update from MySkoda API: %s", err)
 
@@ -334,7 +334,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
         try:
             air_conditioning = await self.myskoda.get_air_conditioning(self.vin)
         except ClientResponseError as err:
-            handle_aiohttp_error("AC update", err, self.hass, self.config)
+            handle_aiohttp_error("AC update", err, self.hass, self.entry)
         except ClientError as err:
             raise UpdateFailed("Error getting update from MySkoda API: %s", err)
 
@@ -355,7 +355,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
         try:
             auxiliary_heating = await self.myskoda.get_auxiliary_heating(self.vin)
         except ClientResponseError as err:
-            handle_aiohttp_error("Auxiliary update", err, self.hass, self.config)
+            handle_aiohttp_error("Auxiliary update", err, self.hass, self.entry)
         except ClientError as err:
             raise UpdateFailed("Error getting update from MySkoda API: %s", err)
 
@@ -371,7 +371,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
         try:
             status = await self.myskoda.get_status(self.vin)
         except ClientResponseError as err:
-            handle_aiohttp_error("vehicle status", err, self.hass, self.config)
+            handle_aiohttp_error("vehicle status", err, self.hass, self.entry)
         except ClientError as err:
             raise UpdateFailed("Error getting update from MySkoda API: %s", err)
 
@@ -387,7 +387,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
         try:
             departure_info = await self.myskoda.get_departure_timers(self.vin)
         except ClientResponseError as err:
-            handle_aiohttp_error("departure info", err, self.hass, self.config)
+            handle_aiohttp_error("departure info", err, self.hass, self.entry)
         except ClientError as err:
             raise UpdateFailed("Error getting update from MySkoda API: %s", err)
 
@@ -403,7 +403,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
         try:
             vehicle = await self.myskoda.get_vehicle(self.vin)
         except ClientResponseError as err:
-            handle_aiohttp_error("vehicle update", err, self.hass, self.config)
+            handle_aiohttp_error("vehicle update", err, self.hass, self.entry)
         except ClientError as err:
             raise UpdateFailed("Error getting update from MySkoda API: %s", err)
 
@@ -422,7 +422,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
             await asyncio.sleep(60)  # GPS is not updated immediately, wait 60 seconds
             positions = await self.myskoda.get_positions(self.vin)
         except ClientResponseError as err:
-            handle_aiohttp_error("positions", err, self.hass, self.config)
+            handle_aiohttp_error("positions", err, self.hass, self.entry)
         except ClientError as err:
             raise UpdateFailed("Error getting update from MySkoda API: %s", err)
 

--- a/custom_components/myskoda/lock.py
+++ b/custom_components/myskoda/lock.py
@@ -56,7 +56,7 @@ class DoorLock(MySkodaLock):
 
     @property
     def available(self) -> bool:
-        if not self.coordinator.config.options.get(CONF_SPIN):
+        if not self.coordinator.entry.options.get(CONF_SPIN):
             return False
         return True
 
@@ -77,18 +77,18 @@ class DoorLock(MySkodaLock):
             _LOGGER.error("Failed to unlock vehicle: %s", exc)
 
     async def async_lock(self, **kwargs) -> None:
-        if self.coordinator.config.options.get(CONF_SPIN):
+        if self.coordinator.entry.options.get(CONF_SPIN):
             await self._async_lock_unlock(
-                lock=True, spin=self.coordinator.config.options.get(CONF_SPIN)
+                lock=True, spin=self.coordinator.entry.options.get(CONF_SPIN)
             )
             _LOGGER.info("Sent command to lock the vehicle.")
         else:
             _LOGGER.error("Cannot lock car: No S-PIN set.")
 
     async def async_unlock(self, **kwargs) -> None:
-        if self.coordinator.config.options.get(CONF_SPIN):
+        if self.coordinator.entry.options.get(CONF_SPIN):
             await self._async_lock_unlock(
-                lock=False, spin=self.coordinator.config.options.get(CONF_SPIN)
+                lock=False, spin=self.coordinator.entry.options.get(CONF_SPIN)
             )
             _LOGGER.info("Sent command to unlock the vehicle.")
         else:

--- a/custom_components/myskoda/number.py
+++ b/custom_components/myskoda/number.py
@@ -50,7 +50,7 @@ class MySkodaNumber(MySkodaEntity, NumberEntity):
         all_capabilities_present = all(
             self.vehicle.has_capability(cap) for cap in self.required_capabilities()
         )
-        readonly = self.coordinator.config.options.get(CONF_READONLY)
+        readonly = self.coordinator.entry.options.get(CONF_READONLY)
 
         return all_capabilities_present and not readonly
 

--- a/custom_components/myskoda/switch.py
+++ b/custom_components/myskoda/switch.py
@@ -77,7 +77,7 @@ class MySkodaSwitch(MySkodaEntity, SwitchEntity):
         all_capabilities_present = all(
             self.vehicle.has_capability(cap) for cap in self.required_capabilities()
         )
-        readonly = self.coordinator.config.options.get(CONF_READONLY)
+        readonly = self.coordinator.entry.options.get(CONF_READONLY)
 
         return all_capabilities_present and not readonly
 


### PR DESCRIPTION
This renames references to ConfigEntry from `config` to `entry`:
- `config` is already used in relation to configurations of various climate entries
- The naming was inconsistent, sometimes `config`, sometimes `entry`

Found this while working on #447 and it annoyed me :grin: 