### PR TITLE
Pull data from REST API when HA has launched

### DIFF
--- a/custom_components/myskoda/coordinator.py
+++ b/custom_components/myskoda/coordinator.py
@@ -174,6 +174,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
                     "MySkoda has finished starting up. Scheduling post-start tasks for vin %s.",
                     vin,
                 )
+                await self._async_update_data()
                 try:
                     coord = hass.data[DOMAIN][config.entry_id][COORDINATORS][vin]
                     if not coord.myskoda.mqtt and not coord._mqtt_connecting:


### PR DESCRIPTION
After PR #447 all the sensors do not have a value after booting HA. This fixes that.