### PR TITLE
fix sunroof sensor not being created

### DIFF
--- a/custom_components/myskoda/binary_sensor.py
+++ b/custom_components/myskoda/binary_sensor.py
@@ -221,7 +221,8 @@ class SunroofOpen(StatusBinarySensor):
                 return
             return status.detail.sunroof == OpenState.OPEN
 
-    def is_supported(self) -> bool:
+    @property
+    def available(self) -> bool:
         if status := self._status():
             return (
                 super().is_supported()


### PR DESCRIPTION
missed this one in #517 - Sunroof sensors is created for all vehicles, and set unavailable for those without this feature