### PR TITLE
Revert partial update when in SETUP state

### DIFF
--- a/custom_components/myskoda/coordinator.py
+++ b/custom_components/myskoda/coordinator.py
@@ -161,7 +161,9 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
             _LOGGER.debug("Performing initial data fetch for vin %s", self.vin)
             try:
                 user = await self.myskoda.get_user()
-                vehicle = await self._async_get_minimal_data()
+                # - Disabled until we find a way to schedule an update when HA is started
+                # vehicle = await self._async_get_minimal_data()
+                vehicle = await self._async_get_vehicle_data()
             except ClientResponseError as err:
                 handle_aiohttp_error(
                     "setup user and vehicle", err, self.hass, self.entry


### PR DESCRIPTION
Using partial update in its current form leaves sensors without value between startup and first poll.
Disable the feature for now until we solve this.