### PR TITLE
change required capabilities for some sensors

### DIFF
--- a/custom_components/myskoda/sensor.py
+++ b/custom_components/myskoda/sensor.py
@@ -268,8 +268,8 @@ class ChargingPower(ChargingSensor):
         if status := self._status():
             return status.charge_power_in_kw
 
-    def forbidden_capabilities(self) -> list[CapabilityId]:
-        return [CapabilityId.CHARGING_MQB]
+    def required_capabilities(self) -> list[CapabilityId]:
+        return [CapabilityId.CHARGING, CapabilityId.EXTENDED_CHARGING_SETTINGS]
 
 
 class AddBlueRange(MySkodaSensor):
@@ -515,8 +515,8 @@ class TargetBatteryPercentage(ChargingSensor):
         if charging := self._charging():
             return charging.settings.target_state_of_charge_in_percent
 
-    def forbidden_capabilities(self) -> list[CapabilityId]:
-        return [CapabilityId.CHARGING_MQB]
+    def required_capabilities(self) -> list[CapabilityId]:
+        return [CapabilityId.CHARGING, CapabilityId.EXTENDED_CHARGING_SETTINGS]
 
 
 class Mileage(MySkodaSensor):
@@ -692,8 +692,8 @@ class ChargingRate(ChargingSensor):
         if status := self._status():
             return status.charging_rate_in_kilometers_per_hour
 
-    def forbidden_capabilities(self) -> list[CapabilityId]:
-        return [CapabilityId.CHARGING_MQB]
+    def required_capabilities(self) -> list[CapabilityId]:
+        return [CapabilityId.CHARGING, CapabilityId.EXTENDED_CHARGING_SETTINGS]
 
 
 class LastUpdated(MySkodaSensor):


### PR DESCRIPTION
ChargingPower, ChargingRate, TargetBatteryPercentage are now created if `EXTENDED_CHARGING_SETTINGS` and `CHARGING` capability is present