### PR TITLE
Add support for odometer update event

### DIFF
--- a/custom_components/myskoda/coordinator.py
+++ b/custom_components/myskoda/coordinator.py
@@ -20,6 +20,7 @@ from myskoda.event import (
     EventAccess,
     EventAirConditioning,
     EventDeparture,
+    EventOdometer,
     EventOperation,
     ServiceEvent,
     ServiceEventTopic,
@@ -255,6 +256,8 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
                 await self._on_air_conditioning_event(event)
             if event.topic == ServiceEventTopic.DEPARTURE:
                 await self._on_departure_event(event)
+            if event.topic == ServiceEventTopic.ODOMETER:
+                await self._on_odometer_event(event)
 
     async def _on_operation_event(self, event: EventOperation) -> None:
         # Store the last MAX_STORED_OPERATIONS operations
@@ -359,12 +362,38 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
     async def _on_departure_event(self, event: EventDeparture):
         await self.update_positions()
 
+    async def _on_odometer_event(self, event: EventOdometer):
+        await self.update_odometer()
+
     def _unsub_refresh(self):
         return
 
     def set_updated_vehicle(self, vehicle: Vehicle) -> None:
         self.data.vehicle = vehicle
         self.async_set_updated_data(self.data)
+
+    async def update_odometer(self) -> None:
+        _LOGGER.debug("Updating odometer information for %s", self.vin)
+
+        maint_info = health_info = vehicle = None
+
+        try:
+            maint_info = await self.myskoda.get_maintenance(self.vin)
+
+            if self.data.vehicle.health:
+                health_info = await self.myskoda.get_health(self.vin)
+        except ClientResponseError as err:
+            handle_aiohttp_error("odometer", err, self.hass, self.entry)
+        except ClientError as err:
+            raise UpdateFailed("Error getting update from MySkoda API: %s", err)
+
+        if maint_info or health_info:
+            vehicle = self.data.vehicle
+            if maint_info:
+                vehicle.maintenance = maint_info
+            if health_info:
+                vehicle.health = health_info
+            self.set_updated_vehicle(vehicle)
 
     async def _update_driving_range(self) -> None:
         driving_range = None


### PR DESCRIPTION
The odometer service-event was added in `myskoda v0.20.0`, this adds handling of this event in the integration.

If the event is fired, the maintance info will be updated, and if there is health information, this will also be updated and pushed into HA.