### PR TITLE
Fix update failing when user endpoint cached

### DIFF
--- a/custom_components/myskoda/coordinator.py
+++ b/custom_components/myskoda/coordinator.py
@@ -220,6 +220,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
                     user = await self.myskoda.get_user()
                 else:
                     _LOGGER.debug("Skipping user update - cache is still valid.")
+                    user = self.data.user
             else:
                 user = await self.myskoda.get_user()
 


### PR DESCRIPTION
This fixes a bug introduced by #614 causing updates to fail when user endpoint is cached