### PR TITLE
Automatically enable/disable entity on write action

### DIFF
--- a/custom_components/myskoda/button.py
+++ b/custom_components/myskoda/button.py
@@ -62,6 +62,14 @@ class MySkodaButton(MySkodaEntity, ButtonEntity):
 
         return all_capabilities_present and not readonly
 
+    def _disable_button(self):
+        self._is_enabled = False
+        self.async_write_ha_state()
+
+    def _enable_button(self):
+        self._is_enabled = True
+        self.async_write_ha_state()
+
     @property
     def available(self) -> bool:
         """Return whether the button is available to be pressed."""
@@ -82,18 +90,13 @@ class HonkFlash(MySkodaButton):
         if not self._is_enabled:
             return  # Ignore presses when disabled
 
-        # Disable the button while handling the press
-        self._is_enabled = False
-        self.async_write_ha_state()
-
+        self._disable_button()
         try:
             await self.coordinator.myskoda.honk_flash(self.vehicle.info.vin)
         except OperationFailedError as exc:
             _LOGGER.error("Failed honk and flash: %s", exc)
         finally:
-            # Re-enable the button
-            self._is_enabled = True
-            self.async_write_ha_state()
+            self._enable_button()
 
     def required_capabilities(self) -> list[CapabilityId]:
         return [CapabilityId.HONK_AND_FLASH]
@@ -111,18 +114,13 @@ class Flash(MySkodaButton):
         if not self._is_enabled:
             return  # Ignore presses when disabled
 
-        # Disable the button while handling the press
-        self._is_enabled = False
-        self.async_write_ha_state()
-
+        self._disable_button()
         try:
             await self.coordinator.myskoda.flash(self.vehicle.info.vin)
         except OperationFailedError as exc:
             _LOGGER.error("Failed to flash lights: %s", exc)
         finally:
-            # Re-enable the button
-            self._is_enabled = True
-            self.async_write_ha_state()
+            self._enable_button()
 
     def required_capabilities(self) -> list[CapabilityId]:
         return [CapabilityId.HONK_AND_FLASH]

--- a/custom_components/myskoda/button.py
+++ b/custom_components/myskoda/button.py
@@ -52,7 +52,7 @@ class MySkodaButton(MySkodaEntity, ButtonEntity):
 
     def __init__(self, coordinator: MySkodaDataUpdateCoordinator, vin: str):
         super().__init__(coordinator, vin)
-        self._is_enabled = True
+        self._is_enabled: bool = True
 
     def is_supported(self) -> bool:
         all_capabilities_present = all(
@@ -149,7 +149,7 @@ class GenerateFixtures(MySkodaButton):
         vin: str,
     ):
         super().__init__(coordinator, vin)
-        self._is_enabled = True  # Track whether the button is enabled
+        self._is_enabled: bool = True  # Track whether the button is enabled
 
     @property
     def available(self) -> bool:

--- a/custom_components/myskoda/number.py
+++ b/custom_components/myskoda/number.py
@@ -21,6 +21,7 @@ from myskoda.models.info import CapabilityId
 from myskoda.mqtt import OperationFailedError
 
 from .const import API_COOLDOWN_IN_SECONDS, CONF_READONLY, COORDINATORS, DOMAIN
+from .coordinator import MySkodaDataUpdateCoordinator
 from .entity import MySkodaEntity
 from .utils import add_supported_entities
 
@@ -47,6 +48,10 @@ class MySkodaNumber(MySkodaEntity, NumberEntity):
     Base class for all number entities in the MySkoda integration.
     """
 
+    def __init__(self, coordinator: MySkodaDataUpdateCoordinator, vin: str):
+        super().__init__(coordinator, vin)
+        self._is_enabled: bool = True
+
     def is_supported(self) -> bool:
         all_capabilities_present = all(
             self.vehicle.has_capability(cap) for cap in self.required_capabilities()
@@ -54,6 +59,19 @@ class MySkodaNumber(MySkodaEntity, NumberEntity):
         readonly = self.coordinator.entry.options.get(CONF_READONLY)
 
         return all_capabilities_present and not readonly
+
+    def _disable_number(self):
+        self._is_enabled = False
+        self.async_write_ha_state()
+
+    def _enable_number(self):
+        self._is_enabled = True
+        self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        """Indicates if the number is available."""
+        return self._is_enabled
 
 
 class ChargeLimit(MySkodaNumber):
@@ -82,12 +100,18 @@ class ChargeLimit(MySkodaNumber):
 
     @Throttle(timedelta(seconds=API_COOLDOWN_IN_SECONDS))
     async def async_set_native_value(self, value: float):  # noqa: D102
+        if not self._is_enabled:
+            return
+
+        self._disable_number()
         try:
             await self.coordinator.myskoda.set_charge_limit(
                 self.vehicle.info.vin, int(value)
             )
         except OperationFailedError as exc:
             _LOGGER.error("Failed to set charging limit: %s", exc)
+        finally:
+            self._enable_number()
 
     def required_capabilities(self) -> list[CapabilityId]:
         return [CapabilityId.CHARGING]

--- a/custom_components/myskoda/switch.py
+++ b/custom_components/myskoda/switch.py
@@ -80,7 +80,7 @@ class MySkodaSwitch(MySkodaEntity, SwitchEntity):
 
     def __init__(self, coordinator: MySkodaDataUpdateCoordinator, vin: str):
         super().__init__(coordinator, vin)
-        self._is_enabled = True
+        self._is_enabled: bool = True
 
     def is_supported(self) -> bool:
         all_capabilities_present = all(


### PR DESCRIPTION
This adds a visual cue to HA users that the entity currently cannot be pressed:

When a write-action to MySkoda is happening, the entity is temporarily disabled.

When the write-action is done, or errored, the entity is re-enabled so it can be pressed again.

This also means that when a throttle is hit because the user is hitting a certain action too often, the absence of entity disable/enable becomes a visual cue that in fact nothing happened.

This is mostly a copy of what was done for the "Generate Fixtures" button, but i think it works nicely!