### PR TITLE
Force data refresh when an operation is done

### DIFF
--- a/custom_components/myskoda/coordinator.py
+++ b/custom_components/myskoda/coordinator.py
@@ -306,12 +306,12 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
             OperationName.STOP_WINDOW_HEATING,
             OperationName.SET_AIR_CONDITIONING_TIMERS,
         ]:
-            await self.update_air_conditioning()
+            await self._update_air_conditioning()
         if event.operation.operation in [
             OperationName.START_AUXILIARY_HEATING,
             OperationName.STOP_AUXILIARY_HEATING,
         ]:
-            await self.update_auxiliary_heating()
+            await self._update_auxiliary_heating()
         if event.operation.operation in [
             OperationName.UPDATE_CHARGE_LIMIT,
             OperationName.UPDATE_CARE_MODE,
@@ -320,16 +320,16 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
             OperationName.STOP_CHARGING,
             OperationName.UPDATE_AUTO_UNLOCK_PLUG,
         ]:
-            await self.update_charging()
+            await self._update_charging()
         if event.operation.operation in [
             OperationName.LOCK,
             OperationName.UNLOCK,
         ]:
-            await self.update_status(immediate=True)
+            await self._update_status()
         if event.operation.operation in [
             OperationName.UPDATE_DEPARTURE_TIMERS,
         ]:
-            await self.update_departure_info()
+            await self._update_departure_info()
 
     async def _on_charging_event(self, event: EventCharging):
         vehicle = self.data.vehicle


### PR DESCRIPTION
This effectively disables the use of the debouncer when an Operation type event reports a status has changed.

Rationale here: We know something has changed, and we know the car is online at the moment, so wakeup is not needed.
Using a debouncer in this case has proved some updates to be skipped completely.

Fixes #542 