### PR TITLE
Remove voluptuous from dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3570,4 +3570,4 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<3.14"
-content-hash = "b1c1036f57e64af9888fb7527a7618e3690672fef551e819684d30b31bec9810"
+content-hash = "17e69bf551a390b144ee74c4d12460fb20eae16015746f01a9f6f3c705a49042"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ package-mode = false
 [tool.poetry.dependencies]
 python = ">=3.13,<3.14"
 homeassistant = "^2025.3.0"
-voluptuous = "^0.15.2"
 myskoda = "^0.21.1"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
voluptuous is already a dependency from HomeAssistant, we do not need to depend on it ourselves