### PR TITLE
Update all relevant sensors when receiving EventCharging

### DIFF
--- a/custom_components/myskoda/climate.py
+++ b/custom_components/myskoda/climate.py
@@ -6,6 +6,8 @@ from datetime import timedelta
 from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityDescription,
+)
+from homeassistant.components.climate.const import (
     ClimateEntityFeature,
     HVACAction,
     HVACMode,

--- a/custom_components/myskoda/config_flow.py
+++ b/custom_components/myskoda/config_flow.py
@@ -13,9 +13,8 @@ from homeassistant.config_entries import (
     ConfigFlow as BaseConfigFlow,
     ConfigFlowResult,
     OptionsFlow,
-    callback,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import callback, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.schema_config_entry_flow import (

--- a/custom_components/myskoda/entity.py
+++ b/custom_components/myskoda/entity.py
@@ -1,6 +1,6 @@
 """MySkoda Entity base classes."""
 
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from myskoda import Vehicle


### PR DESCRIPTION
Always update `charging` and `driving_range` when we receive an event of type `EventCharging`.

The data contained in the charging event itself does not have all the related sensor information, causing charging releated sensors not to be updated at all when `EventCharging` is emitted more frequently than the polling interval.

Fixes #484 