### PR TITLE
Fix dependencies for sensors

### DIFF
--- a/custom_components/myskoda/sensor.py
+++ b/custom_components/myskoda/sensor.py
@@ -538,9 +538,6 @@ class Mileage(MySkodaSensor):
         elif maint_report := self.vehicle.maintenance.maintenance_report:
             return maint_report.mileage_in_km
 
-    def required_capabilities(self) -> list[CapabilityId]:
-        return [CapabilityId.VEHICLE_HEALTH_INSPECTION]
-
 
 class InspectionInterval(MySkodaSensor):
     """The number of days before next inspection."""
@@ -558,9 +555,6 @@ class InspectionInterval(MySkodaSensor):
         if maintenance_report := self.vehicle.maintenance.maintenance_report:
             return maintenance_report.inspection_due_in_days
 
-    def required_capabilities(self) -> list[CapabilityId]:
-        return [CapabilityId.VEHICLE_HEALTH_INSPECTION]
-
 
 class InspectionIntervalKM(MySkodaSensor):
     """The number of kilometers before inspection is due."""
@@ -577,9 +571,6 @@ class InspectionIntervalKM(MySkodaSensor):
     def native_value(self) -> int | None:  # noqa: S102
         if maintenance_report := self.vehicle.maintenance.maintenance_report:
             return maintenance_report.inspection_due_in_km
-
-    def required_capabilities(self) -> list[CapabilityId]:
-        return [CapabilityId.VEHICLE_HEALTH_INSPECTION, CapabilityId.FUEL_STATUS]
 
 
 class OilServiceIntervalDays(MySkodaSensor):
@@ -599,7 +590,7 @@ class OilServiceIntervalDays(MySkodaSensor):
             return maintenance_report.oil_service_due_in_days
 
     def required_capabilities(self) -> list[CapabilityId]:
-        return [CapabilityId.VEHICLE_HEALTH_INSPECTION, CapabilityId.FUEL_STATUS]
+        return [CapabilityId.FUEL_STATUS]
 
 
 class OilServiceIntervalKM(MySkodaSensor):
@@ -619,7 +610,7 @@ class OilServiceIntervalKM(MySkodaSensor):
             return maintenance_report.oil_service_due_in_km
 
     def required_capabilities(self) -> list[CapabilityId]:
-        return [CapabilityId.VEHICLE_HEALTH_INSPECTION, CapabilityId.FUEL_STATUS]
+        return [CapabilityId.FUEL_STATUS]
 
 
 class ChargeType(ChargingSensor):


### PR DESCRIPTION
As pointed out in #687 we sometimes do not show the service interval in km sensor.
Source of this turned out to be misconfigured dependencies on sensors.

The `Maintenance` object is always present, and does not have any requirements for mileage and inspection, looking at our fixtures. For oil inspection, it does depend on just the `FUEL_STATUS` capability.

This adjusts the sensors to meet those capabilities