### PR TITLE
Swap source for mileage sensor, health endpoint is now cached

### DIFF
--- a/custom_components/myskoda/sensor.py
+++ b/custom_components/myskoda/sensor.py
@@ -532,11 +532,11 @@ class Mileage(MySkodaSensor):
 
     @property
     def native_value(self) -> int | None:  # noqa: D102
-        if health := self.vehicle.health:
-            return health.mileage_in_km
-        # If we have disabled the health endpoint, use this as fallback
-        elif maint_report := self.vehicle.maintenance.maintenance_report:
+        if maint_report := self.vehicle.maintenance.maintenance_report:
             return maint_report.mileage_in_km
+        # If the maint report does not have mileage, use vehicle health as fallback
+        elif health := self.vehicle.health:
+            return health.mileage_in_km
 
 
 class InspectionInterval(MySkodaSensor):


### PR DESCRIPTION
In release v1.21.2 caching was added for the health endpoint to avoid 429 errors on this healthpoint for some car models. This sensor used this endpoint, which made the results being cached.

Swap this for the mileage report that we get from another endpoint, which seems to have a much higher tolerance for 429 errors for all models.

Fixes #693 