### PR TITLE
Fix AC timer availability

### DIFF
--- a/custom_components/myskoda/switch.py
+++ b/custom_components/myskoda/switch.py
@@ -750,7 +750,6 @@ class ACTimerSwitch(MySkodaSwitch):
         """Initialize the departure timer switch."""
         super().__init__(coordinator, vin)  # Initialize parent class (MySkodaEntity)
         self.timer_id = timer_id  # Store the specific timer ID for each subclass
-        self._is_enabled: bool = bool(self.get_timer())
 
     def get_timer(self) -> AirConditioningTimer | None:
         """Retrieve the specific ac timer by ID."""
@@ -768,7 +767,7 @@ class ACTimerSwitch(MySkodaSwitch):
     @property
     def available(self) -> bool:
         """Determine whether the sensor is available."""
-        return self._is_enabled
+        return self._is_enabled and bool(self.get_timer())
 
     @property
     def is_on(self) -> bool | None:


### PR DESCRIPTION
Fixes #706 

In #662 UI improvements to pushing buttons, toggling switches etc wee introduced, making these entities available only when no other action is currently running.

This introduced a regression due to the fact that AC data only is available after startup, since we improved startup times by only requesting initially what's needed for entity creation.