### PR TITLE
Implement sensor indicating time left until AC has reached target

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ If your desired language is not available, please [open an issue](https://github
 - Fuel Level
 - Combustion range
 - Electric range
+- Estimated Time To Reach Target Temperature
 
 #### Last Updated sensor
 

--- a/custom_components/myskoda/translations/en.json
+++ b/custom_components/myskoda/translations/en.json
@@ -227,6 +227,9 @@
                     "ready_for_charging": "Ready for Charging"
                 }
             },
+            "estimated_time_left_to_reach_target_temperature": {
+                  "name": "Time to reach target temperature"
+            },
             "inspection": {
                 "name": "Next Inspection"
             },


### PR DESCRIPTION
This introduces a sensor for vehicles that advertise having Air Conditioning:

`estimated_time_left_to_reach_target_temperature`

The value is calculated from the API `estimated_date_time_to_reach_target_temperature`, which indicates a point in time that is estimated when the AC reaches set time.

A time difference between now and that point in time is calculated. 
When that time difference is negative, the sensor will indicate 0, to make it clear there is no time left to reach target temperature.

Fixes #678 