### PR TITLE
Fix getting coordinators in async_unload_entry

### DIFF
--- a/custom_components/myskoda/__init__.py
+++ b/custom_components/myskoda/__init__.py
@@ -127,10 +127,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: MySkodaConfigEntry) -> b
 
 async def async_unload_entry(hass: HomeAssistant, entry: MySkodaConfigEntry) -> bool:
     """Unload a config entry."""
-    for active_coordinators in hass.data[DOMAIN][entry.entry_id].get(COORDINATORS, []):
-        coord = next(iter(active_coordinators.values()), None)
-        if coord:
-            await coord.myskoda.disconnect()
+    coordinators: dict[str, MySkodaDataUpdateCoordinator] = hass.data[DOMAIN][
+        entry.entry_id
+    ].get(COORDINATORS, {})
+    for coord in coordinators.values():
+        await coord.myskoda.disconnect()
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)


### PR DESCRIPTION
Error:

```
025-04-08 08:03:42.404 ERROR (MainThread) [homeassistant.config_entries] Error unloading entry user.name@gmail.com for myskoda
Traceback (most recent call last):
  File "/Users/dfabrice/dev/github/homeassistant-core/homeassistant/config_entries.py", line 967, in async_unload
    result = await component.async_unload_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dfabrice/dev/github/homeassistant-core/config/custom_components/myskoda/__init__.py", line 131, in async_unload_entry
    coord = next(iter(active_coordinators.values()), None)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'values'
```