### PR TITLE
Bump version to 1.23.0

### DIFF
--- a/custom_components/myskoda/manifest.json
+++ b/custom_components/myskoda/manifest.json
@@ -19,5 +19,5 @@
   "requirements": [
     "myskoda==1.0.0"
   ],
-  "version": "1.22.0"
+  "version": "1.23.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.poetry]
 name = "homeassistant-myskoda"
-version = "1.22.0"
 description = "HomeAssistant integration for MySkoda."
 authors = [
     "Frederick Gnodtke <frederick@gnodtke.net>",


### PR DESCRIPTION
Drop version from pyproject.toml since it's not being used there (we don't package anything)

Planning to do a pre-release of this one first to confirm behavior after the large refactor.