### PR TITLE
fix: prevent value/type error when setting last mileage value

### DIFF
--- a/custom_components/myskoda/sensor.py
+++ b/custom_components/myskoda/sensor.py
@@ -540,7 +540,10 @@ class Mileage(MySkodaSensor):
         last_value = 0
         last_state = self.hass.states.get(self.entity_id)
         if last_state and last_state.state:
-            last_value = int(last_state.state)
+            try:
+                last_value = int(last_state.state)
+            except (ValueError, TypeError):
+                pass  # value may initially be 'unavailable' or 'None'
 
         mileage_in_km = None
         if maint_report := self.vehicle.maintenance.maintenance_report:


### PR DESCRIPTION
Introduced in #767

Woops.

Can happen on startup.

```
2025-05-01T09:36:22.033377902Z   File "/config/custom_components/myskoda/sensor.py", line 548, in native_value
2025-05-01T09:36:22.033395550Z     last_value = int(last_state.state)
2025-05-01T09:36:22.033412235Z ValueError: invalid literal for int() with base 10: 'unavailable'
```