### PR TITLE
fix: update HA after updating events/operations

### DIFF
--- a/custom_components/myskoda/coordinator.py
+++ b/custom_components/myskoda/coordinator.py
@@ -124,8 +124,6 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
     async def _async_update_data(self) -> State:
         """Called by parent class during setup and scheduled refresh."""
         config = self.data.config if self.data and self.data.config else Config()
-        operations = self.operations
-        service_events = self.service_events
 
         if self.entry.state == ConfigEntryState.SETUP_IN_PROGRESS:
             if getattr(self, "_startup_called", False):
@@ -161,7 +159,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
             async_at_started(
                 hass=self.hass, at_start_cb=_async_finish_startup
             )  # Schedule post-setup tasks
-            return State(vehicle, user, config, operations, service_events)
+            return State(vehicle, user, config, self.operations, self.service_events)
 
         # Regular update
         _LOGGER.debug("Performing scheduled refresh of all data for vin %s", self.vin)
@@ -188,7 +186,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
             self.data.vehicle,
             self.data.user,
             self.data.config,
-            self.data.operations,
+            self.operations,
             self.service_events,
         )
 
@@ -225,6 +223,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
                     self.operations.popitem(last=False)
         if event.type == EventType.SERVICE_EVENT:
             self.service_events.appendleft(event.event)
+        self.async_set_updated_data(self.data)
 
     def _unsub_refresh(self):
         return


### PR DESCRIPTION
Fixes #765

Previously you'd have to wait for the next myskoda update or scheduled update to see events/operation updates in HA.

Now it's at the time of the operation/events, e.g.

```
2025-05-01T09:43:41.478567362Z 2025-05-01 09:43:41.458 DEBUG (MainThread) [myskoda.myskoda] Processing operation event: ...operation=<OperationName.UPDATE_CARE_MODE: 'update-care-mode'>, status=<OperationStatus.IN_PROGRESS: 'IN_PROGRESS'>, error_code=None, timestamp=None), type=<EventType.OPERATION: 'operation-request'>)
...
2025-05-01T09:44:41.289862310Z 2025-05-01 09:44:41.256 DEBUG (MainThread) [myskoda.myskoda] Processing operation event: ...operation=<OperationName.UPDATE_CARE_MODE: 'update-care-mode'>, status=<OperationStatus.COMPLETED_SUCCESS: 'COMPLETED_SUCCESS'>, error_code=None, timestamp=None), type=<EventType.OPERATION: 'operation-request'>)
```

![image](https://github.com/user-attachments/assets/1d5c3d60-4f4e-4b49-80d0-db26fde04294)
