### PR TITLE
feat: add button to wake up the car

### DIFF
--- a/custom_components/myskoda/button.py
+++ b/custom_components/myskoda/button.py
@@ -32,7 +32,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the button platform."""
     add_supported_entities(
-        available_entities=[HonkFlash, Flash],
+        available_entities=[HonkFlash, Flash, WakeUp],
         coordinators=hass.data[DOMAIN][config.entry_id][COORDINATORS],
         async_add_entities=async_add_entities,
     )
@@ -86,7 +86,7 @@ class HonkFlash(MySkodaButton):
 
         self._disable_button()
         try:
-            await self.coordinator.myskoda.honk_flash(self.vehicle.info.vin)
+            await self.coordinator.myskoda.honk_flash(self.vin)
         except OperationFailedError as exc:
             _LOGGER.error("Failed honk and flash: %s", exc)
         finally:
@@ -110,7 +110,7 @@ class Flash(MySkodaButton):
 
         self._disable_button()
         try:
-            await self.coordinator.myskoda.flash(self.vehicle.info.vin)
+            await self.coordinator.myskoda.flash(self.vin)
         except OperationFailedError as exc:
             _LOGGER.error("Failed to flash lights: %s", exc)
         finally:
@@ -118,3 +118,38 @@ class Flash(MySkodaButton):
 
     def required_capabilities(self) -> list[CapabilityId]:
         return [CapabilityId.HONK_AND_FLASH]
+
+
+class WakeUp(MySkodaButton):
+    """Explicitly wake up the vehicle.
+
+    Disabled by default to limit accidental use.
+    """
+
+    entity_description = ButtonEntityDescription(
+        key="wakeup",
+        translation_key="wakeup",
+        device_class=ButtonDeviceClass.RESTART,
+        entity_registry_enabled_default=False,
+    )
+
+    @Throttle(timedelta(seconds=API_COOLDOWN_IN_SECONDS))
+    async def async_press(self) -> None:
+        if not self._is_enabled:
+            return
+
+        self._disable_button()
+        try:
+            await self.coordinator.myskoda.wakeup(self.vin)
+        except OperationFailedError as exc:
+            _LOGGER.error("Failed to wake up vehicle: %s", exc)
+        finally:
+            self._enable_button()
+
+    def is_supported(self) -> bool:
+        """Some models have VEHICLE_WAKE_UP while others have VEHICLE_WAKE_UP_TRIGGER."""
+        capabilities = [
+            CapabilityId.VEHICLE_WAKE_UP,
+            CapabilityId.VEHICLE_WAKE_UP_TRIGGER,
+        ]
+        return any(self.vehicle.has_capability(cap) for cap in capabilities)

--- a/custom_components/myskoda/icons.json
+++ b/custom_components/myskoda/icons.json
@@ -292,6 +292,9 @@
             },
             "flash": {
                 "default": "mdi:car-parking-lights"
+            },
+            "wakeup": {
+                "default": "mdi:car-connected"
             }
         }
     }

--- a/custom_components/myskoda/translations/en.json
+++ b/custom_components/myskoda/translations/en.json
@@ -354,6 +354,9 @@
             },
             "flash": {
                 "name": "Flash"
+            },
+            "wakeup": {
+                "name": "Wake Up Car"
             }
         }
     },

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -109,10 +109,15 @@ NOTE: not all vehicles report all service events.
 
 ## Buttons
 
-| Key          | Name           | Notes |
-|--------------|----------------|-------|
-| `honk_flash` | Honk and Flash |       |
-| `flash`      | Flash          |       |
+| Key          | Name           | Notes                         |
+|--------------|----------------|-------------------------------|
+| `honk_flash` | Honk and Flash |                               |
+| `flash`      | Flash          |                               |
+| `wakeup`     | Wake Up Car    | :warning: Disabled by default |
+
+### Wake Up Car
+
+This button will result in a wake-up request being sent directly to the car. In order to protect the 12V battery most models have a strict limit on the number of times this can occur before requiring the car to be started. **USE WITH CARE!**
 
 ## Climate
 
@@ -130,9 +135,9 @@ NOTE: not all vehicles report all service events.
 
 ## Device Tracker
 
-| Key                         | Name            | Notes                           |
-|-----------------------------|-----------------|---------------------------------|
-| `<VIN>_device_tracker`              | Charge Limit    | In % [50-100] in steps of 10    |
+| Key                    | Name         | Notes                        |
+|------------------------|--------------|------------------------------|
+| `<VIN>_device_tracker` | Charge Limit | In % [50-100] in steps of 10 |
 
 Location of vehicles are exposed as device trackers. While the vehicle is moving the Skoda API does not return GPS coordinates and the device tracker will report the location `vehicle_in_motion`.
 


### PR DESCRIPTION
Fixes: #762

Disabled by default to limit accidental use.

Adding service calls (actions) looked like it would actually be more work/complexity so I ended up going for a third option after the discussion in #762: directly add a new button, but keep it disabled by default. This means the use has to first intentionally find, update and enable the entity before being able to use it.

Seems to work ok on my Enyaq although I can't tell if it really does wake the car

```
2025-05-06T07:20:48.734252002Z 2025-05-06 07:20:48.729 DEBUG (MainThread) [myskoda.myskoda] Trace: POST https://mysmob.api.connect.skoda-auto.cz/api/v1/vehicle-wake - response: 202 (0 bytes)
```

I didn't see any MQTT event but I'm not seeing _any_ events right now so I think the MQTT broker might be down...