### PR TITLE
feat: add 3 new binary sensors using connection-status API endpoint

### DIFF
--- a/custom_components/myskoda/translations/en.json
+++ b/custom_components/myskoda/translations/en.json
@@ -130,6 +130,15 @@
                     "on": "Open"
                 }
             },
+            "vehicle_battery_protection": {
+                "name": "Battery Protection (beta)"
+            },
+            "vehicle_reachable": {
+                "name": "Connected (beta)"
+            },
+            "vehicle_in_motion": {
+                "name": "In motion (beta)"
+            },
             "window_open_front_left": {
                 "name": "Window Front Left",
                 "state": {


### PR DESCRIPTION
This adds 3 new `BinarySensor`s, representing the data that we receive from the new endpoint.

`vehicle_reachable`: On if the vehicle can be reached by the MySkoda servers
`vehicle_battery_protection`: On if the vehicle currently is in Battery Protection mode
`vehicle_in_motion`: On if the vehicle currently is in motion. This seems to be a duplication of the motion detection we do in the `device_tracker` currently, we'll have to see how to move forward with this as/when we have more experience on the matter.

Since we do not have much information about the timeliness, availability and correctness of the endpoint, the default translation now shows this as "beta".

Fixes #751 