### PR TITLE
fix: refinements for readiness sensors

### DIFF
--- a/custom_components/myskoda/binary_sensor.py
+++ b/custom_components/myskoda/binary_sensor.py
@@ -89,7 +89,7 @@ class VehicleConnectionBinarySensor(MySkodaBinarySensor):
         return self.vehicle.connection_status
 
     def required_capabilities(self) -> list[CapabilityId]:
-        return [CapabilityId.STATE]
+        return [CapabilityId.READINESS]
 
 
 class ChargerConnected(AirConditioningBinarySensor):

--- a/custom_components/myskoda/icons.json
+++ b/custom_components/myskoda/icons.json
@@ -55,6 +55,18 @@
             "door_open_rear_right": {
                 "default": "mdi:car-door"
             },
+            "vehicle_battery_protection": {
+                "default": "mdi:battery-heart",
+                "state": {
+                    "on": "mdi:battery-alert-variant"
+                }
+            },
+            "vehicle_reachable": {
+                "default": "mdi:car-connected"
+            },
+            "vehicle_in_motion": {
+                "default": "motion"
+            },
             "window_open_front_left": {
                 "default": "mdi:car-door"
             },

--- a/custom_components/myskoda/icons.json
+++ b/custom_components/myskoda/icons.json
@@ -65,7 +65,7 @@
                 "default": "mdi:car-connected"
             },
             "vehicle_in_motion": {
-                "default": "motion"
+                "default": "mdi:motion"
             },
             "window_open_front_left": {
                 "default": "mdi:car-door"


### PR DESCRIPTION
Some refinements after collecting user feedback:

- Apparently the sensors are only available on Enyaq and Elroq cars. Collected fixtures teach us those are the only ones currently supporting the `READINESS` capability. Since the endpoint has the same name in it, it seems logical to gate the sensors behind this capability
- Add icons more suitable than the default ones from HA

A lot of thanks to all the beta users!