### PR TITLE
chore: instruct hacs to download the zip not checkout the repo

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,7 @@
     "name": "MySkoda",
     "render_readme": true,
     "hide_default_branch": true,
-    "homeassistant": "2025.3.2"
+    "homeassistant": "2025.3.2",
+    "zip_release": true,
+    "filename": "homeassistant-myskoda.zip"
 }


### PR DESCRIPTION
Downloading the zip is faster than checkout of the repo, and we create it in CI a while now.