### PR TITLE
fix(i10n): remove beta from sensor names

### DIFF
--- a/custom_components/myskoda/manifest.json
+++ b/custom_components/myskoda/manifest.json
@@ -19,5 +19,5 @@
   "requirements": [
     "myskoda==1.2.3"
   ],
-  "version": "1.25.0"
+  "version": "1.25.1"
 }

--- a/custom_components/myskoda/translations/en.json
+++ b/custom_components/myskoda/translations/en.json
@@ -75,13 +75,13 @@
                 "name": "Door Rear Right"
             },
             "vehicle_battery_protection": {
-                "name": "Battery Protection (beta)"
+                "name": "Battery Protection"
             },
             "vehicle_reachable": {
-                "name": "Connected (beta)"
+                "name": "Connected"
             },
             "vehicle_in_motion": {
-                "name": "In motion (beta)"
+                "name": "In motion"
             },
             "window_open_front_left": {
                 "name": "Window Front Left"

--- a/custom_components/myskoda/translations/nl.json
+++ b/custom_components/myskoda/translations/nl.json
@@ -75,13 +75,13 @@
                 "name": "Deur rechtsachter"
             },
             "vehicle_battery_protection": {
-                "name": "Batterijbescherming (bèta)"
+                "name": "Batterijbescherming"
             },
             "vehicle_reachable": {
-                "name": "Verbonden (bèta)"
+                "name": "Verbonden"
             },
             "vehicle_in_motion": {
-                "name": "In beweging (bèta)"
+                "name": "In beweging"
             },
             "window_open_front_left": {
                 "name": "Raam linksvoor"

--- a/custom_components/myskoda/translations/pt-BR.json
+++ b/custom_components/myskoda/translations/pt-BR.json
@@ -1,4 +1,4 @@
-
+{
     "config": {
         "abort": {
             "already_configured": "O dispositivo já está ajustado",

--- a/custom_components/myskoda/translations/pt-BR.json
+++ b/custom_components/myskoda/translations/pt-BR.json
@@ -1,4 +1,4 @@
-{
+
     "config": {
         "abort": {
             "already_configured": "O dispositivo já está ajustado",
@@ -75,13 +75,13 @@
                 "name": "Porta traseira direita: "
             },
             "vehicle_battery_protection": {
-                "name": "Proteção de bateria (beta)"
+                "name": "Proteção de bateria"
             },
             "vehicle_reachable": {
-                "name": "Conectado (beta)"
+                "name": "Conectado"
             },
             "vehicle_in_motion": {
-                "name": "Moção (beta)"
+                "name": "Moção"
             },
             "window_open_front_left": {
                 "name": "Janela frontal esquerda: "

--- a/custom_components/myskoda/translations/pt.json
+++ b/custom_components/myskoda/translations/pt.json
@@ -75,13 +75,13 @@
                 "name": "Porta traseira direita: "
             },
             "vehicle_battery_protection": {
-                "name": "Proteção de bateria (beta)"
+                "name": "Proteção de bateria"
             },
             "vehicle_reachable": {
-                "name": "Conectado (beta)"
+                "name": "Conectado"
             },
             "vehicle_in_motion": {
-                "name": "Em moção (beta)"
+                "name": "Em moção"
             },
             "window_open_front_left": {
                 "name": "Janela frontal esquerda: "


### PR DESCRIPTION
Since the sensors are part of the release, they should not be named beta anymore.

Also bump the version to prepare for releasing just this fix.