### PR TITLE
feat: use assumed state during climate actions

### DIFF
--- a/custom_components/myskoda/climate.py
+++ b/custom_components/myskoda/climate.py
@@ -2,6 +2,8 @@
 
 import logging
 from datetime import timedelta
+from enum import StrEnum
+from typing import Any
 
 from homeassistant.components.climate import (
     ClimateEntity,
@@ -13,9 +15,11 @@ from homeassistant.components.climate.const import (
     HVACMode,
 )
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import DiscoveryInfoType  # pyright: ignore [reportAttributeAccessIssue]
+from homeassistant.helpers.typing import (
+    DiscoveryInfoType,  # pyright: ignore [reportAttributeAccessIssue]
+)
 from homeassistant.util import Throttle
 
 from myskoda.models.air_conditioning import (
@@ -27,8 +31,8 @@ from myskoda.models.air_conditioning import (
 from myskoda.models.auxiliary_heating import (
     AuxiliaryConfig,
     AuxiliaryHeating,
-    AuxiliaryState,
     AuxiliaryStartMode,
+    AuxiliaryState,
 )
 from myskoda.models.info import CapabilityId
 from myskoda.mqtt import OperationFailedError
@@ -60,19 +64,18 @@ async def async_setup_entry(
     )
 
 
-class MySkodaClimate(MySkodaEntity, ClimateEntity):
-    """Climate control for MySkoda vehicles."""
+class OptimisticAttribute(StrEnum):
+    """Enum for trackable optimistic attributes."""
 
-    entity_description = ClimateEntityDescription(
-        key="climate",
-        translation_key="climate",
-    )
+    TARGET_TEMPERATURE = "target_temperature"
+    HVAC_MODE = "hvac_mode"
+    HVAC_ACTION = "hvac_action"
+
+
+class MySkodaClimateEntity(MySkodaEntity, ClimateEntity):
+    """Base class for all MySkoda Climate entities."""
+
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
-    _attr_supported_features = (
-        ClimateEntityFeature.TARGET_TEMPERATURE
-        | ClimateEntityFeature.TURN_ON
-        | ClimateEntityFeature.TURN_OFF
-    )
 
     def __init__(self, coordinator: MySkodaDataUpdateCoordinator, vin: str) -> None:  # noqa: D107
         super().__init__(
@@ -80,46 +83,13 @@ class MySkodaClimate(MySkodaEntity, ClimateEntity):
             vin,
         )
         ClimateEntity.__init__(self)
-        self._is_enabled: bool = True
-
-    def _air_conditioning(self) -> AirConditioning | None:
-        return self.vehicle.air_conditioning
-
-    def _enable_climate(self):
-        self._is_enabled = True
-        self.async_write_ha_state()
-
-    def _disable_climate(self):
-        self._is_enabled = False
-        self._async_write_ha_state()
+        self._operation_in_progress: bool = False
+        self._optimistic_values: dict[OptimisticAttribute, Any] = {}
 
     @property
-    def available(self) -> bool:
-        """Indicator to see if the climate entitiy is currently available."""
-        return self._is_enabled
-
-    @property
-    def hvac_modes(self) -> list[HVACMode]:  # noqa: D102
-        return [HVACMode.HEAT_COOL, HVACMode.OFF]
-
-    @property
-    def hvac_mode(self) -> HVACMode | None:  # noqa: D102
-        if ac := self._air_conditioning():
-            if (
-                ac.state != AirConditioningState.OFF
-                and ac.state != AirConditioningState.HEATING_AUXILIARY
-            ):
-                return HVACMode.HEAT_COOL
-            return HVACMode.OFF
-
-    @property
-    def hvac_action(self) -> HVACAction | None:  # noqa: D102
-        if ac := self._air_conditioning():
-            if ac.state == "HEATING":
-                return HVACAction.HEATING
-            if ac.state == "COOLING":
-                return HVACAction.COOLING
-            return HVACAction.OFF
+    def assumed_state(self) -> bool:
+        """Return True if any optimistic value is set."""
+        return len(self._optimistic_values) > 0
 
     @property
     def min_temp(self) -> float:
@@ -131,8 +101,119 @@ class MySkodaClimate(MySkodaEntity, ClimateEntity):
         """Return the maximum temperature that can be set."""
         return 30.0  # Restrict to a maximum of 30°C
 
+    def _air_conditioning(self) -> AirConditioning | None:
+        return self.vehicle.air_conditioning
+
+    def _set_optimistic_value(self, attr: OptimisticAttribute, value: Any):
+        self._optimistic_values[attr] = value
+        self.async_write_ha_state()
+
+    def _unset_optimistic_value(self, attr: OptimisticAttribute):
+        self._optimistic_values.pop(attr, None)
+        self.async_write_ha_state()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Clear optimistic values when fresh data arrives and no operation in progress."""
+        if not self._operation_in_progress:
+            self._optimistic_values = {}
+        super()._handle_coordinator_update()
+
+    async def _stop_auxiliary_heating(self) -> None:
+        self._operation_in_progress = True
+        try:
+            await self.coordinator.myskoda.stop_auxiliary_heating(self.vehicle.info.vin)
+        finally:
+            self._operation_in_progress = False
+
+    async def _start_auxiliary_heating(
+        self, spin: str, config: AuxiliaryConfig
+    ) -> None:
+        self._operation_in_progress = True
+        try:
+            await self.coordinator.myskoda.start_auxiliary_heating(
+                vin=self.vehicle.info.vin,
+                spin=spin,
+                config=config,
+            )
+        finally:
+            self._operation_in_progress = False
+
+    async def _stop_air_conditioning(self) -> None:
+        self._operation_in_progress = True
+        try:
+            await self.coordinator.myskoda.stop_air_conditioning(self.vehicle.info.vin)
+        finally:
+            self._operation_in_progress = False
+
+    async def _start_air_conditioning(self, temperature: float) -> None:
+        self._operation_in_progress = True
+        try:
+            await self.coordinator.myskoda.start_air_conditioning(
+                self.vehicle.info.vin, temperature
+            )
+        finally:
+            self._operation_in_progress = False
+
+    async def _set_target_temperature(self, temperature: float) -> None:
+        self._operation_in_progress = True
+        try:
+            await self.coordinator.myskoda.set_target_temperature(
+                self.vehicle.info.vin, temperature
+            )
+        finally:
+            self._operation_in_progress = False
+
+
+class MySkodaClimate(MySkodaClimateEntity):
+    """Climate control for MySkoda vehicles."""
+
+    entity_description = ClimateEntityDescription(
+        key="climate",
+        translation_key="climate",
+    )
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
+    )
+
+    @property
+    def hvac_modes(self) -> list[HVACMode]:  # noqa: D102
+        return [HVACMode.HEAT_COOL, HVACMode.OFF]
+
+    @property
+    def hvac_mode(self) -> HVACMode | None:  # noqa: D102
+        if hvac_mode := self._optimistic_values.get(OptimisticAttribute.HVAC_MODE):
+            return hvac_mode
+
+        if ac := self._air_conditioning():
+            if (
+                ac.state != AirConditioningState.OFF
+                and ac.state != AirConditioningState.HEATING_AUXILIARY
+            ):
+                return HVACMode.HEAT_COOL
+            return HVACMode.OFF
+
+    @property
+    def hvac_action(self) -> HVACAction | None:  # noqa: D102
+        if hvac_action := self._optimistic_values.get(OptimisticAttribute.HVAC_ACTION):
+            return hvac_action
+
+        if ac := self._air_conditioning():
+            if ac.state == "HEATING":
+                return HVACAction.HEATING
+            if ac.state == "COOLING":
+                return HVACAction.COOLING
+            return HVACAction.OFF
+
     @property
     def target_temperature(self) -> None | float:  # noqa: D102
+        if target_temperature := self._optimistic_values.get(
+            OptimisticAttribute.TARGET_TEMPERATURE
+        ):
+            return target_temperature
+
         if ac := self._air_conditioning():
             target_temperature = ac.target_temperature
             if target_temperature is None:
@@ -141,47 +222,37 @@ class MySkodaClimate(MySkodaEntity, ClimateEntity):
 
     @Throttle(timedelta(seconds=API_COOLDOWN_IN_SECONDS))
     async def async_set_hvac_mode(self, hvac_mode: HVACMode):  # noqa: D102
-        if not self._is_enabled:
+        if not (ac := self._air_conditioning()):
             return
 
-        if ac := self._air_conditioning():
-            target_temperature = ac.target_temperature
-            if target_temperature is None:
-                return
+        if not (target_temperature := ac.target_temperature):
+            return
 
-            if hvac_mode == HVACMode.HEAT_COOL:
-                self._disable_climate()
-                if ac.state == AirConditioningState.HEATING_AUXILIARY:
-                    _LOGGER.info("Auxiliary heating detected, stopping first.")
-                    try:
-                        await self.coordinator.myskoda.stop_auxiliary_heating(
-                            self.vehicle.info.vin
-                        )
-                    except OperationFailedError as exc:
-                        _LOGGER.error(
-                            "Failed to stop aux heater, aborting action: %s", exc
-                        )
-                        self._enable_climate()
-                        return
-                _LOGGER.info("Starting Air conditioning.")
+        self._set_optimistic_value(OptimisticAttribute.HVAC_MODE, hvac_mode)
+        if hvac_mode == HVACMode.HEAT_COOL:
+            if ac.state == AirConditioningState.HEATING_AUXILIARY:
+                _LOGGER.info("Auxiliary heating detected, stopping first.")
                 try:
-                    await self.coordinator.myskoda.start_air_conditioning(
-                        self.vehicle.info.vin,
-                        target_temperature.temperature_value,
-                    )
+                    await self._stop_auxiliary_heating()
                 except OperationFailedError as exc:
-                    _LOGGER.error("Failed to start air conditioning: %s", exc)
-                finally:
-                    self._enable_climate()
-            else:
-                _LOGGER.info("Stopping Air conditioning.")
-                try:
-                    await self.coordinator.myskoda.stop_air_conditioning(
-                        self.vehicle.info.vin
-                    )
-                except OperationFailedError as exc:
-                    _LOGGER.error("Failed to stop air conditioning: %s", exc)
-            _LOGGER.info("HVAC mode set to %s.", hvac_mode)
+                    self._unset_optimistic_value(OptimisticAttribute.HVAC_MODE)
+                    _LOGGER.error("Failed to stop aux heater, aborting action: %s", exc)
+                    return
+            _LOGGER.info("Starting Air conditioning.")
+            try:
+                await self._start_air_conditioning(target_temperature.temperature_value)
+
+            except OperationFailedError as exc:
+                self._unset_optimistic_value(OptimisticAttribute.HVAC_MODE)
+                _LOGGER.error("Failed to start air conditioning: %s", exc)
+
+        else:
+            _LOGGER.info("Stopping Air conditioning.")
+            try:
+                await self._stop_air_conditioning()
+            except OperationFailedError as exc:
+                _LOGGER.error("Failed to stop air conditioning: %s", exc)
+        _LOGGER.info("HVAC mode set to %s.", hvac_mode)
 
     async def async_turn_on(self):  # noqa: D102
         await self.async_set_hvac_mode(HVACMode.HEAT_COOL)
@@ -191,9 +262,6 @@ class MySkodaClimate(MySkodaEntity, ClimateEntity):
 
     @Throttle(timedelta(seconds=API_COOLDOWN_IN_SECONDS))
     async def async_set_temperature(self, **kwargs):  # noqa: D102
-        if not self._is_enabled:
-            return
-
         temp = kwargs[ATTR_TEMPERATURE]
         # Ensure the temperature stays within range
         if temp < self.min_temp:
@@ -201,16 +269,13 @@ class MySkodaClimate(MySkodaEntity, ClimateEntity):
         elif temp > self.max_temp:
             temp = self.max_temp
 
-        self._disable_climate()
+        self._set_optimistic_value(OptimisticAttribute.TARGET_TEMPERATURE, temp)
         try:
-            await self.coordinator.myskoda.set_target_temperature(
-                self.vehicle.info.vin, temp
-            )
-            _LOGGER.info("Target temperature for AC set to %s.", temp)
+            await self._set_target_temperature(temp)
+            _LOGGER.info("Target temperature set to %s.", temp)
         except OperationFailedError as exc:
-            _LOGGER.error("Failed to set AC target temperature: %s", exc)
-        finally:
-            self._enable_climate()
+            self._unset_optimistic_value(OptimisticAttribute.TARGET_TEMPERATURE)
+            _LOGGER.error("Failed to set target temperature: %s", exc)
 
     def required_capabilities(self) -> list[CapabilityId]:
         return [CapabilityId.AIR_CONDITIONING]
@@ -224,27 +289,23 @@ class MySkodaClimate(MySkodaEntity, ClimateEntity):
         return all_capabilities_present and not readonly
 
 
-class AuxiliaryHeater(MySkodaEntity, ClimateEntity):
+class AuxiliaryHeater(MySkodaClimateEntity):
     """Auxiliary heater control for MySkoda vehicles."""
 
     entity_description = ClimateEntityDescription(
         key="auxiliary_heater",
         translation_key="auxiliary_heater",
     )
-    _attr_temperature_unit = UnitOfTemperature.CELSIUS
 
     def __init__(self, coordinator: MySkodaDataUpdateCoordinator, vin: str) -> None:  # noqa: D107
         super().__init__(
             coordinator,
             vin,
         )
-        ClimateEntity.__init__(self)
         self._is_enabled: bool = bool(self.coordinator.entry.options.get(CONF_SPIN))
-
         self._attr_supported_features = (
             ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TURN_OFF
         )
-
         if self.has_any_capability(
             [
                 CapabilityId.AUXILIARY_HEATING_TEMPERATURE_SETTING,
@@ -253,19 +314,8 @@ class AuxiliaryHeater(MySkodaEntity, ClimateEntity):
         ):
             self._attr_supported_features |= ClimateEntityFeature.TARGET_TEMPERATURE
 
-    def _air_conditioning(self) -> AirConditioning | None:
-        return self.vehicle.air_conditioning
-
     def _auxiliary_heating(self) -> AuxiliaryHeating | None:
         return self.vehicle.auxiliary_heating
-
-    def _enable_climate(self):
-        self._is_enabled = True
-        self.async_write_ha_state()
-
-    def _disable_climate(self):
-        self._is_enabled = False
-        self.async_write_ha_state()
 
     @property
     def _target_temperature(self) -> TargetTemperature | None:
@@ -334,6 +384,9 @@ class AuxiliaryHeater(MySkodaEntity, ClimateEntity):
 
     @property
     def hvac_mode(self) -> HVACMode | None:  # noqa: D102
+        if hvac_mode := self._optimistic_values.get(OptimisticAttribute.HVAC_MODE):
+            return hvac_mode
+
         if state := self._state:
             if state == AuxiliaryState.HEATING_AUXILIARY:
                 return HVACMode.HEAT
@@ -343,6 +396,9 @@ class AuxiliaryHeater(MySkodaEntity, ClimateEntity):
 
     @property
     def hvac_action(self) -> HVACAction | None:  # noqa: D102
+        if hvac_action := self._optimistic_values.get(OptimisticAttribute.HVAC_ACTION):
+            return hvac_action
+
         if state := self._state:
             if state == AuxiliaryState.HEATING_AUXILIARY:
                 return HVACAction.HEATING
@@ -351,128 +407,86 @@ class AuxiliaryHeater(MySkodaEntity, ClimateEntity):
             return HVACAction.OFF
 
     @property
-    def min_temp(self) -> float:
-        """Return the minimum temperature that can be set."""
-        return 15.5  # Restrict to a minimum of 15.5°C
-
-    @property
-    def max_temp(self) -> float:
-        """Return the maximum temperature that can be set."""
-        return 30.0  # Restrict to a maximum of 30°C
-
-    @property
     def target_temperature(self) -> None | float:  # noqa: D102
+        if target_temperature := self._optimistic_values.get(
+            OptimisticAttribute.TARGET_TEMPERATURE
+        ):
+            return target_temperature
+
         if target_temperature := self._target_temperature:
             return target_temperature.temperature_value
 
     @Throttle(timedelta(seconds=API_COOLDOWN_IN_SECONDS))
     async def async_set_hvac_mode(self, hvac_mode: HVACMode):  # noqa: D102
-        if not self._is_enabled:
+        if not (state := self._state):
+            _LOGGER.error("Can't retrieve air-conditioning info")
             return
 
-        if state := self._state:
-            self._disable_climate()
+        self._set_optimistic_value(OptimisticAttribute.HVAC_MODE, hvac_mode)
 
-            async def handle_mode(desired_state, start_mode=None, **kwargs):
-                if state == desired_state:
-                    _LOGGER.info("%s already running.", state)
-                    return
+        async def handle_mode(desired_state, start_mode=None, **kwargs):
+            if state == desired_state:
+                _LOGGER.info("%s already running.", state)
+                return
 
-                if state != AirConditioningState.OFF:
-                    _LOGGER.info("%s mode detected, stopping first.", state)
-                    try:
-                        await self.coordinator.myskoda.stop_air_conditioning(
-                            self.vehicle.info.vin
-                        )
-                    except OperationFailedError as exc:
-                        _LOGGER.error("Failed to stop air conditioning: %s", exc)
-                        self._enable_climate()
-                        return
-
-                config = AuxiliaryConfig(
-                    duration_in_seconds=self._duration_in_seconds,
-                    start_mode=start_mode,
-                    **kwargs,
-                )
-                spin = self.coordinator.entry.options.get(CONF_SPIN)
-                if spin is None:
-                    _LOGGER.error("Cannot start %s: No S-PIN set.", desired_state)
-                    self._enable_climate()
-                    return
-
-                _LOGGER.info("Starting %s [%s]", start_mode or "heating", config)
+            if state != AirConditioningState.OFF:
+                _LOGGER.info("%s mode detected, stopping first.", state)
                 try:
-                    await self.coordinator.myskoda.start_auxiliary_heating(
-                        vin=self.vehicle.info.vin,
-                        spin=spin,
-                        config=config,
-                    )
+                    await self._stop_air_conditioning()
                 except OperationFailedError as exc:
-                    _LOGGER.error("Failed to start aux heating: %s", exc)
-                finally:
-                    self._enable_climate()
+                    self._unset_optimistic_value(OptimisticAttribute.HVAC_MODE)
+                    _LOGGER.error("Failed to stop air conditioning: %s", exc)
+                    return
 
-            if hvac_mode == HVACMode.HEAT:
-                await handle_mode(
-                    desired_state=AirConditioningState.HEATING_AUXILIARY,
-                    target_temperature=self._target_temperature,
-                    start_mode=self._start_mode,
-                    heater_source=self._heater_source,
-                )
+            config = AuxiliaryConfig(
+                duration_in_seconds=self._duration_in_seconds,
+                start_mode=start_mode,
+                **kwargs,
+            )
+            spin = self.coordinator.entry.options.get(CONF_SPIN)
+            if spin is None:
+                self._unset_optimistic_value(OptimisticAttribute.HVAC_MODE)
+                _LOGGER.error("Cannot start %s: No S-PIN set.", desired_state)
+                return
 
-            elif hvac_mode == HVACMode.FAN_ONLY:
-                await handle_mode(
-                    desired_state=AirConditioningState.VENTILATION,
-                    start_mode=AuxiliaryStartMode.VENTILATION,
-                )
+            _LOGGER.info("Starting %s [%s]", start_mode or "heating", config)
+            try:
+                await self._start_auxiliary_heating(spin=spin, config=config)
+            except OperationFailedError as exc:
+                self._unset_optimistic_value(OptimisticAttribute.HVAC_MODE)
+                _LOGGER.error("Failed to start aux heating: %s", exc)
 
-            else:
-                if state == AirConditioningState.OFF:
-                    _LOGGER.info("Auxiliary heater already OFF.")
-                else:
-                    _LOGGER.info("Stopping Auxiliary heater.")
-                    try:
-                        await self.coordinator.myskoda.stop_auxiliary_heating(
-                            self.vehicle.info.vin
-                        )
-                    except OperationFailedError as exc:
-                        _LOGGER.error("Failed to stop aux heater: %s", exc)
-                    finally:
-                        self._enable_climate()
+        if hvac_mode == HVACMode.HEAT:
+            await handle_mode(
+                desired_state=AirConditioningState.HEATING_AUXILIARY,
+                target_temperature=self._target_temperature,
+                start_mode=self._start_mode,
+                heater_source=self._heater_source,
+            )
 
-            _LOGGER.info("Auxiliary HVAC mode set to %s.", hvac_mode)
+        elif hvac_mode == HVACMode.FAN_ONLY:
+            await handle_mode(
+                desired_state=AirConditioningState.VENTILATION,
+                start_mode=AuxiliaryStartMode.VENTILATION,
+            )
+
         else:
-            _LOGGER.error("Can't retrieve air-conditioning info")
+            if state == AirConditioningState.OFF:
+                _LOGGER.info("Auxiliary heater already OFF.")
+            else:
+                _LOGGER.info("Stopping Auxiliary heater.")
+                try:
+                    await self._stop_auxiliary_heating()
+                except OperationFailedError as exc:
+                    _LOGGER.error("Failed to stop aux heater: %s", exc)
+
+        _LOGGER.info("Auxiliary HVAC mode set to %s.", hvac_mode)
 
     async def async_turn_on(self):  # noqa: D102
         await self.async_set_hvac_mode(HVACMode.HEAT)
 
     async def async_turn_off(self):  # noqa: D102
         await self.async_set_hvac_mode(HVACMode.OFF)
-
-    @Throttle(timedelta(seconds=API_COOLDOWN_IN_SECONDS))
-    async def async_set_temperature(self, **kwargs):  # noqa: D102
-        if not self._is_enabled:
-            return
-
-        temp = kwargs[ATTR_TEMPERATURE]
-        if temp is not None:
-            # Ensure the temperature stays within range
-            if temp < self.min_temp:
-                temp = self.min_temp
-            elif temp > self.max_temp:
-                temp = self.max_temp
-
-        self._disable_climate()
-        try:
-            await self.coordinator.myskoda.set_target_temperature(
-                self.vehicle.info.vin, temp
-            )
-            _LOGGER.info("Target temperature for auxiliary heater set to %s.", temp)
-        except OperationFailedError as exc:
-            _LOGGER.error("Failed to set aux heater temperature: %s", exc)
-        finally:
-            self._enable_climate()
 
     def is_supported(self) -> bool:
         """Return true if any supported capability is present."""


### PR DESCRIPTION
Tentative implementation using assumed_state as discussed in #757.

I don't love it but it does the trick and haven't come up with something nicer yet.

Instead of disabling the entity completely assume the state when setting something (mode, action, temp) until the action completes and new data from the API is received.

Fixes #757