### PR TITLE
chore: remove deprecated MySkoda ssl_context

### DIFF
--- a/custom_components/myskoda/__init__.py
+++ b/custom_components/myskoda/__init__.py
@@ -5,32 +5,30 @@ from __future__ import annotations
 import logging
 
 from aiohttp import ClientResponseError, InvalidUrlClientError
-
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
-from homeassistant.util.ssl import get_default_context
+
 from myskoda import (
-    MySkoda,
     AuthorizationFailedError,
+    MySkoda,
 )
-from myskoda.myskoda import TRACE_CONFIG
 from myskoda.auth.authorization import (
     CSRFError,
-    TermsAndConditionsError,
     MarketingConsentError,
+    TermsAndConditionsError,
 )
+from myskoda.myskoda import TRACE_CONFIG
 
-
-from .const import CONF_USERNAME, CONF_PASSWORD, COORDINATORS, DOMAIN, VINLIST
+from .const import CONF_PASSWORD, CONF_USERNAME, COORDINATORS, DOMAIN, VINLIST
 from .coordinator import MySkodaConfigEntry, MySkodaDataUpdateCoordinator
 from .error_handlers import handle_aiohttp_error
 from .issues import (
     async_create_tnc_issue,
-    async_delete_tnc_issue,
     async_delete_spin_issue,
+    async_delete_tnc_issue,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -60,7 +58,7 @@ def myskoda_instantiate(
     session = async_create_clientsession(
         hass, trace_configs=trace_configs, auto_cleanup=False
     )
-    return MySkoda(session, get_default_context(), mqtt_enabled=mqtt_enabled)
+    return MySkoda(session=session, mqtt_enabled=mqtt_enabled)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: MySkodaConfigEntry) -> bool:

--- a/custom_components/myskoda/config_flow.py
+++ b/custom_components/myskoda/config_flow.py
@@ -6,16 +6,16 @@ import logging
 from typing import Any
 
 import voluptuous as vol
-
 from aiohttp.client_exceptions import ClientResponseError
-
 from homeassistant.config_entries import (
     ConfigFlow as BaseConfigFlow,
+)
+from homeassistant.config_entries import (
     ConfigFlowResult,
     OptionsFlow,
 )
-from homeassistant.core import callback, HomeAssistant
-from homeassistant.exceptions import HomeAssistantError, ConfigEntryNotReady
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.schema_config_entry_flow import (
     SchemaCommonFlowHandler,
@@ -23,26 +23,26 @@ from homeassistant.helpers.schema_config_entry_flow import (
     SchemaFlowFormStep,
     SchemaOptionsFlowHandler,
 )
-from homeassistant.util.ssl import get_default_context
+
 from myskoda import MySkoda
 from myskoda.auth.authorization import (
     AuthorizationError,
-    NotAuthorizedError,
     AuthorizationFailedError,
-    TermsAndConditionsError,
     MarketingConsentError,
+    NotAuthorizedError,
+    TermsAndConditionsError,
 )
 
 from .const import (
-    DOMAIN,
     CONF_PASSWORD,
     CONF_POLL_INTERVAL,
-    CONF_POLL_INTERVAL_MIN,
     CONF_POLL_INTERVAL_MAX,
+    CONF_POLL_INTERVAL_MIN,
+    CONF_READONLY,
     CONF_SPIN,
     CONF_TRACING,
     CONF_USERNAME,
-    CONF_READONLY,
+    DOMAIN,
 )
 from .coordinator import MySkodaConfigEntry
 
@@ -69,9 +69,7 @@ async def validate_options_input(
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> None:
     """Check that the inputs are valid."""
-    hub = MySkoda(
-        async_get_clientsession(hass), get_default_context(), mqtt_enabled=False
-    )
+    hub = MySkoda(async_get_clientsession(hass), mqtt_enabled=False)
 
     await hub.connect(data[CONF_USERNAME], data[CONF_PASSWORD])
     await hub.disconnect()


### PR DESCRIPTION
This doesn't do anything anymore since asyncio-paho was replaced with aiomqtt in skodaconnect/myskoda#140

(import order changes due to setting up VSCode to let ruff auto-organize imports on save)