### PR TITLE
fix: rename unique_id of binary sensor locks from 'locked' to 'lock'

### DIFF
--- a/custom_components/myskoda/__init__.py
+++ b/custom_components/myskoda/__init__.py
@@ -287,7 +287,12 @@ async def async_migrate_entry(hass: HomeAssistant, entry: MySkodaConfigEntry) ->
 
             for entity in entry_entities:
                 if entity.unique_id in old_entities:
-                    new_unique_id = entity.unique_id.replace("locked", "lock")
+                    if entity.unique_id.endswith(("charger_locked", "doors_locked")):
+                        new_unique_id = entity.unique_id.replace("locked", "lock")
+                    else:
+                        new_unique_id = entity.unique_id.replace(
+                            "locked", "vehicle_lock"
+                        )
                     _LOGGER.debug(
                         "Renaming entity %s to %s", entity.unique_id, new_unique_id
                     )

--- a/custom_components/myskoda/binary_sensor.py
+++ b/custom_components/myskoda/binary_sensor.py
@@ -111,9 +111,9 @@ class ChargerLocked(AirConditioningBinarySensor):
     """Detect if the charger is locked on the car, or whether it can be unplugged."""
 
     entity_description = BinarySensorEntityDescription(
-        key="charger_locked",
+        key="charger_lock",
         device_class=BinarySensorDeviceClass.LOCK,
-        translation_key="charger_locked",
+        translation_key="charger_lock",
     )
 
     @property
@@ -129,9 +129,9 @@ class Locked(StatusBinarySensor):
     # Keep in mind, a lock that is open, is "ON" for HomeAssistant
 
     entity_description = BinarySensorEntityDescription(
-        key="locked",
+        key="vehicle_lock",
         device_class=BinarySensorDeviceClass.LOCK,
-        translation_key="locked",
+        translation_key="vehicle_lock",
     )
 
     @property
@@ -144,9 +144,9 @@ class DoorsLocked(StatusBinarySensor):
     """Detect whether the doors are locked."""
 
     entity_description = BinarySensorEntityDescription(
-        key="doors_locked",
+        key="doors_lock",
         device_class=BinarySensorDeviceClass.LOCK,
-        translation_key="doors_locked",
+        translation_key="doors_lock",
     )
 
     @property

--- a/custom_components/myskoda/config_flow.py
+++ b/custom_components/myskoda/config_flow.py
@@ -103,7 +103,7 @@ class ConfigFlow(BaseConfigFlow, domain=DOMAIN):
     """Handle a config flow for MySkoda."""
 
     VERSION = 2
-    MINOR_VERSION = 3
+    MINOR_VERSION = 4
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/myskoda/translations/cs.json
+++ b/custom_components/myskoda/translations/cs.json
@@ -38,16 +38,16 @@
             "charger_connected": {
                 "name": "Nabíječka připojena"
             },
-            "charger_locked": {
+            "charger_lock": {
                 "name": "Zámek nabíjení"
             },
-            "doors_locked": {
+            "doors_lock": {
                 "name": "Dveře uzamčené"
             },
             "doors_open": {
                 "name": "Dveře otevřené"
             },
-            "locked": {
+            "vehicle_lock": {
                 "name": "Vozidlo uzamčeno"
             },
             "parkinglights_on": {

--- a/custom_components/myskoda/translations/da.json
+++ b/custom_components/myskoda/translations/da.json
@@ -33,14 +33,14 @@
                     "on": "Tilsluttet"
                 }
             },
-            "charger_locked": {
+            "charger_lock": {
                 "name": "Ladekabel låst",
                 "state": {
                     "off": "Låst",
                     "on": "Låst op"
                 }
             },
-            "doors_locked": {
+            "doors_lock": {
                 "name": "Dørlåst",
                 "state": {
                     "off": "Låst",

--- a/custom_components/myskoda/translations/de.json
+++ b/custom_components/myskoda/translations/de.json
@@ -33,14 +33,14 @@
                     "on": "Eingesteckt"
                 }
             },
-            "charger_locked": {
+            "charger_lock": {
                 "name": "Ladekabelverriegelung",
                 "state": {
                     "off": "Verriegelt",
                     "on": "Entriegelt"
                 }
             },
-            "doors_locked": {
+            "doors_lock": {
                 "name": "Türen geschlossen",
                 "state": {
                     "off": "Verriegelt",
@@ -54,7 +54,7 @@
                     "on": "Geöffnet"
                 }
             },
-            "locked": {
+            "vehicle_lock": {
                 "name": "Fahrzeug verriegelt",
                 "state": {
                     "off": "Verriegelt",

--- a/custom_components/myskoda/translations/en.json
+++ b/custom_components/myskoda/translations/en.json
@@ -38,16 +38,16 @@
             "charger_connected": {
                 "name": "Charger Connected"
             },
-            "charger_locked": {
+            "charger_lock": {
                 "name": "Charge Lock"
             },
-            "doors_locked": {
+            "doors_lock": {
                 "name": "Doors Locked"
             },
             "doors_open": {
                 "name": "Doors Open"
             },
-            "locked": {
+            "vehicle_lock": {
                 "name": "Vehicle Locked"
             },
             "parkinglights_on": {

--- a/custom_components/myskoda/translations/fi.json
+++ b/custom_components/myskoda/translations/fi.json
@@ -34,14 +34,14 @@
                     "on": "Kytketty"
                 }
             },
-            "charger_locked": {
+            "charger_lock": {
                 "name": "Kaapelin lukitus",
                 "state": {
                     "off": "Auki",
                     "on": "Lukittu"
                 }
             },
-            "doors_locked": {
+            "doors_lock": {
                 "name": "Ovien lukitus",
                 "state": {
                     "off": "Lukossa",
@@ -55,7 +55,7 @@
                     "on": "Auki"
                 }
             },
-            "locked": {
+            "vehicle_lock": {
                 "name": "Ajoneuvon lukitus",
                 "state": {
                     "off": "Lukossa",

--- a/custom_components/myskoda/translations/fr.json
+++ b/custom_components/myskoda/translations/fr.json
@@ -33,14 +33,14 @@
                     "on": "Branché"
                 }
             },
-            "charger_locked": {
+            "charger_lock": {
                 "name": "Verrou de charge",
                 "state": {
                     "off": "Verrouillé",
                     "on": "Déverrouillé"
                 }
             },
-            "doors_locked": {
+            "doors_lock": {
                 "name": "Portes verrouillées",
                 "state": {
                     "off": "Verrouillé",
@@ -54,7 +54,7 @@
                     "on": "Ouverte"
                 }
             },
-            "locked": {
+            "vehicle_lock": {
                 "name": "Véhicule verrouillé",
                 "state": {
                     "off": "Verrouillé",

--- a/custom_components/myskoda/translations/hu.json
+++ b/custom_components/myskoda/translations/hu.json
@@ -46,14 +46,14 @@
                     "on": "Bedugva"
                 }
             },
-            "charger_locked": {
+            "charger_lock": {
                 "name": "Töltő reteszelve",
                 "state": {
                     "off": "Zárolva",
                     "on": "Feloldva"
                 }
             },
-            "doors_locked": {
+            "doors_lock": {
                 "name": "Ajtók zárva",
                 "state": {
                     "off": "Zárva",
@@ -67,7 +67,7 @@
                     "on": "Nyitva"
                 }
             },
-            "locked": {
+            "vehicle_lock": {
                 "name": "Jármű zárva",
                 "state": {
                     "off": "Zárva",

--- a/custom_components/myskoda/translations/it.json
+++ b/custom_components/myskoda/translations/it.json
@@ -33,14 +33,14 @@
                     "on": "Collegato"
                 }
             },
-            "charger_locked": {
+            "charger_lock": {
                 "name": "Blocco ricarica",
                 "state": {
                     "off": "Bloccato",
                     "on": "Sbloccato"
                 }
             },
-            "doors_locked": {
+            "doors_lock": {
                 "name": "Porte chiuse",
                 "state": {
                     "off": "Bloccato",
@@ -54,7 +54,7 @@
                     "on": "Aperto"
                 }
             },
-            "locked": {
+            "vehicle_lock": {
                 "name": "Veicolo bloccato",
                 "state": {
                     "off": "Bloccato",

--- a/custom_components/myskoda/translations/nl.json
+++ b/custom_components/myskoda/translations/nl.json
@@ -38,16 +38,16 @@
             "charger_connected": {
                 "name": "Laadkabel"
             },
-            "charger_locked": {
+            "charger_lock": {
                 "name": "Laadkabelvergrendeling"
             },
-            "doors_locked": {
+            "doors_lock": {
                 "name": "Deurvergrendeling"
             },
             "doors_open": {
                 "name": "Deuren"
             },
-            "locked": {
+            "vehicle_lock": {
                 "name": "Voertuigvergrendeling"
             },
             "parkinglights_on": {

--- a/custom_components/myskoda/translations/no.json
+++ b/custom_components/myskoda/translations/no.json
@@ -38,16 +38,16 @@
             "charger_connected": {
                 "name": "Lader tilkoblet"
             },
-            "charger_locked": {
+            "charger_lock": {
                 "name": "Lader Lås"
             },
-            "doors_locked": {
+            "doors_lock": {
                 "name": "Dører låst"
             },
             "doors_open": {
                 "name": "Dører åpne"
             },
-            "locked": {
+            "vehicle_lock": {
                 "name": "Bil låst"
             },
             "parkinglights_on": {

--- a/custom_components/myskoda/translations/pl.json
+++ b/custom_components/myskoda/translations/pl.json
@@ -33,14 +33,14 @@
                     "on": "Podłączony"
                 }
             },
-            "charger_locked": {
+            "charger_lock": {
                 "name": "Blokada kabla ładującego",
                 "state": {
                     "off": "Zablokowany",
                     "on": "Odblokowany"
                 }
             },
-            "doors_locked": {
+            "doors_lock": {
                 "name": "Drzwi zablokowane",
                 "state": {
                     "off": "Zablokowane",
@@ -54,7 +54,7 @@
                     "on": "Otwarte"
                 }
             },
-            "locked": {
+            "vehicle_lock": {
                 "name": "Pojazd zablokowany",
                 "state": {
                     "off": "Zablokowany",

--- a/custom_components/myskoda/translations/pt-BR.json
+++ b/custom_components/myskoda/translations/pt-BR.json
@@ -38,16 +38,16 @@
             "charger_connected": {
                 "name": "Carregador conectado"
             },
-            "charger_locked": {
+            "charger_lock": {
                 "name": "Bloqueio de carga"
             },
-            "doors_locked": {
+            "doors_lock": {
                 "name": "Portas trancadas"
             },
             "doors_open": {
                 "name": "Portas abertas"
             },
-            "locked": {
+            "vehicle_lock": {
                 "name": "Veículo trancado"
             },
             "parkinglights_on": {

--- a/custom_components/myskoda/translations/pt.json
+++ b/custom_components/myskoda/translations/pt.json
@@ -38,16 +38,16 @@
             "charger_connected": {
                 "name": "Carregador conectado"
             },
-            "charger_locked": {
+            "charger_lock": {
                 "name": "Bloqueio de carga"
             },
-            "doors_locked": {
+            "doors_lock": {
                 "name": "Portas trancadas"
             },
             "doors_open": {
                 "name": "Portas abertas"
             },
-            "locked": {
+            "vehicle_lock": {
                 "name": "Veículo trancado"
             },
             "parkinglights_on": {

--- a/custom_components/myskoda/translations/ro.json
+++ b/custom_components/myskoda/translations/ro.json
@@ -33,14 +33,14 @@
                     "on": "Conectat"
                 }
             },
-            "charger_locked": {
+            "charger_lock": {
                 "name": "Încărcător încuiat",
                 "state": {
                     "off": "Blocat",
                     "on": "Deblocat"
                 }
             },
-            "doors_locked": {
+            "doors_lock": {
                 "name": "Uși blocate",
                 "state": {
                     "off": "Blocate",
@@ -54,7 +54,7 @@
                     "on": "Deschise"
                 }
             },
-            "locked": {
+            "vehicle_lock": {
                 "name": "Vehicul încuiat",
                 "state": {
                     "off": "Încuiat",

--- a/custom_components/myskoda/translations/ru.json
+++ b/custom_components/myskoda/translations/ru.json
@@ -38,16 +38,16 @@
             "charger_connected": {
                 "name": "Зарядное устройство подключено"
             },
-            "charger_locked": {
+            "charger_lock": {
                 "name": "Блокировка зарядки"
             },
-            "doors_locked": {
+            "doors_lock": {
                 "name": "Двери заблокированы"
             },
             "doors_open": {
                 "name": "Двери"
             },
-            "locked": {
+            "vehicle_lock": {
                 "name": "Автомобиль заблокирован"
             },
             "parkinglights_on": {

--- a/custom_components/myskoda/translations/sk.json
+++ b/custom_components/myskoda/translations/sk.json
@@ -38,16 +38,16 @@
             "charger_connected": {
                 "name": "Pripojenie nabíjačky"
             },
-            "charger_locked": {
+            "charger_lock": {
                 "name": "Zámka nabíjania"
             },
-            "doors_locked": {
+            "doors_lock": {
                 "name": "Zámok dverí"
             },
             "doors_open": {
                 "name": "Dvere"
             },
-            "locked": {
+            "vehicle_lock": {
                 "name": "Uzamknutie vozidla"
             },
             "parkinglights_on": {

--- a/custom_components/myskoda/translations/sl.json
+++ b/custom_components/myskoda/translations/sl.json
@@ -46,14 +46,14 @@
                     "on": "Priklopljen"
                 }
             },
-            "charger_locked": {
+            "charger_lock": {
                 "name": "Zaklep polnjenja",
                 "state": {
                     "off": "Zaklenjeno",
                     "on": "Odklenjeno"
                 }
             },
-            "doors_locked": {
+            "doors_lock": {
                 "name": "Vrata zaklep",
                 "state": {
                     "off": "Zaklenjeno",
@@ -67,7 +67,7 @@
                     "on": "Odprto"
                 }
             },
-            "locked": {
+            "vehicle_lock": {
                 "name": "Vozilo zaklep",
                 "state": {
                     "off": "Zaklenjeno",

--- a/custom_components/myskoda/translations/sv.json
+++ b/custom_components/myskoda/translations/sv.json
@@ -33,14 +33,14 @@
                     "on": "Inkopplad"
                 }
             },
-            "charger_locked": {
+            "charger_lock": {
                 "name": "Laddningslås",
                 "state": {
                     "off": "Låst",
                     "on": "Olåst"
                 }
             },
-            "doors_locked": {
+            "doors_lock": {
                 "name": "Dörrarna låsta",
                 "state": {
                     "off": "Låsta",
@@ -54,7 +54,7 @@
                     "on": "Öppna"
                 }
             },
-            "locked": {
+            "vehicle_lock": {
                 "name": "Fordonet låst",
                 "state": {
                     "off": "Låst",


### PR DESCRIPTION
This PR changes the suffix in the unique_id of all LOCK type binary sensors from "locked" to "lock" to prevent confusion.

This still needs some testing to see if we migrate correctly.

Fixes #853 