### PR TITLE
chore: Bump myskoda to 2.3.2

### DIFF
--- a/custom_components/myskoda/manifest.json
+++ b/custom_components/myskoda/manifest.json
@@ -17,7 +17,7 @@
     "myskoda"
   ],
   "requirements": [
-    "myskoda==2.2.3"
+    "myskoda==2.3.2"
   ],
   "version": "1.28.3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.13.0"
-dependencies = ["homeassistant>=2025.3.2", "myskoda ~=2.3.0"]
+dependencies = ["homeassistant>=2025.3.2", "myskoda ~=2.3.2"]
 
 [dependency-groups]
 dev = ["homeassistant-stubs>=2025.3.2", "ruff ~=0.11.7", "pyright ~=1.1.400"]

--- a/uv.lock
+++ b/uv.lock
@@ -895,7 +895,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2025.3.2" },
-    { name = "myskoda", specifier = "~=2.3.0" },
+    { name = "myskoda", specifier = "~=2.3.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -1102,7 +1102,7 @@ wheels = [
 
 [[package]]
 name = "myskoda"
-version = "2.3.1"
+version = "2.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1112,9 +1112,9 @@ dependencies = [
     { name = "pyjwt" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/9e/5609677742813b2a179c87da20a9542f3db778b45845fb629f9ce4f1fca0/myskoda-2.3.1.tar.gz", hash = "sha256:58bce27b6c2208b91ab32b40c6a73d58f8c6935640bd38acf2a7c1c9073bcfc0", size = 292410, upload-time = "2025-07-08T12:04:41.975Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/b3/957fc29c592471318ebb41fb6e83f88a0a938c82a5f00f3e77d0130d927b/myskoda-2.3.2.tar.gz", hash = "sha256:c38b802473a1b49c1704e795a73aebf6208a528268e7580dab004da859d91262", size = 292411, upload-time = "2025-07-28T09:54:05.816Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/08/825dfd060a4105f70a8fb70b943b0300a9c17552ef08fabac0dc5391b783/myskoda-2.3.1-py3-none-any.whl", hash = "sha256:b0dcf12e6d9392daf5959130cdbc6f464b98e068f93ac9345d7031477c2d50a5", size = 66719, upload-time = "2025-07-08T12:04:40.558Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e4/ad735b63e5f21160c200dc6393987d5baee9eb418dea2800a50980c1d627/myskoda-2.3.2-py3-none-any.whl", hash = "sha256:0ecf8b301d2406bf986214958963ee7a4b0fb04b5246ce7d87d7f9373c352b1e", size = 66719, upload-time = "2025-07-28T09:54:04.483Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Changes:

- Support for deactivated capabilities (occurs on OTA update)
- Support for new marketing capability
- Update in TLS handling to prevent deprecation warnings
- Adds support for parking positions
- Documentation of app 8.4.0 endpoints