### PR TITLE
fix: align sensor type of battery-protection with sensor values

### DIFF
--- a/custom_components/myskoda/binary_sensor.py
+++ b/custom_components/myskoda/binary_sensor.py
@@ -445,7 +445,7 @@ class VehicleBatteryProtection(VehicleConnectionBinarySensor):
 
     entity_description = BinarySensorEntityDescription(
         key="vehicle_battery_protection",
-        device_class=BinarySensorDeviceClass.PROBLEM,
+        device_class=BinarySensorDeviceClass.RUNNING,
         translation_key="vehicle_battery_protection",
     )
 


### PR DESCRIPTION
Using "Running" from the available device classes seems more fitting than using "Problem".
Fixes #862 