### PR TITLE
Ignore dependabot changes in release notes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels: 
+      - dependencies
+      - ignore-for-release
+      - github_actions
 
   - package-ecosystem: "uv"
     directory: "/"
@@ -13,3 +17,7 @@ updates:
     ignore:
       # Dependabot should not update Home Assistant as that should match the homeassistant key in hacs.json
       - dependency-name: "homeassistant"
+    labels:
+      - dependencies
+      - ignore-for-release
+      - python:uv


### PR DESCRIPTION
Dependabot starts to clutter up the release notes. 

This ignores them by default, we can add them back in by manually removing the label.