### PR TITLE
feat: implement mqtt connection retry loop

### DIFF
--- a/custom_components/myskoda/const.py
+++ b/custom_components/myskoda/const.py
@@ -6,6 +6,7 @@ COORDINATORS = "coordinators"
 # Timing information
 DEFAULT_FETCH_INTERVAL_IN_MINUTES = 30
 API_COOLDOWN_IN_SECONDS = 30.0
+MQTT_RECONNECT_INTERVAL_IN_SECONDS = 300
 
 # Configuration information
 CONF_USERNAME = "email"

--- a/custom_components/myskoda/coordinator.py
+++ b/custom_components/myskoda/coordinator.py
@@ -13,6 +13,7 @@ from aiohttp.client_exceptions import ClientResponseError
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.debounce import Debouncer
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.start import async_at_started
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -28,6 +29,7 @@ from .const import (
     DOMAIN,
     MAX_STORED_OPERATIONS,
     MAX_STORED_SERVICE_EVENTS,
+    MQTT_RECONNECT_INTERVAL_IN_SECONDS,
 )
 from .error_handlers import handle_aiohttp_error
 
@@ -114,6 +116,7 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
         self.service_events: deque = deque(maxlen=MAX_STORED_SERVICE_EVENTS)
         self.entry: MySkodaConfigEntry = entry
         self._mqtt_connecting: bool = False
+        self._mqtt_retry_scheduled: bool = False
         self._startup_called: bool = False
 
     async def _async_update_data(self) -> State:
@@ -140,6 +143,23 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
                     "MySkoda has finished starting up. Scheduling post-start tasks for vin %s.",
                     self.vin,
                 )
+
+                async def _retry_mqtt(_now=None) -> None:
+                    """Retry loop for MQTT connection."""
+                    if not self.myskoda.mqtt and not self._mqtt_connecting:
+                        await self._mqtt_connect()
+                    if not self.myskoda.mqtt and not self._mqtt_retry_scheduled:
+                        _LOGGER.warning(
+                            "Could not connect to MQTT. Retry in %s seconds",
+                            MQTT_RECONNECT_INTERVAL_IN_SECONDS,
+                        )
+                        async_call_later(
+                            hass, MQTT_RECONNECT_INTERVAL_IN_SECONDS, _retry_mqtt
+                        )
+                        self._mqtt_retry_scheduled = True
+                        return
+                    self._mqtt_retry_scheduled = False
+
                 try:
                     coord = hass.data[DOMAIN][self.entry.entry_id][COORDINATORS][
                         self.vin
@@ -149,7 +169,15 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
                             self.hass, coord._mqtt_connect(), "mqtt"
                         )
                 except KeyError:
-                    _LOGGER.debug("Could not connect to MQTT. Waiting for regular poll")
+                    if not self._mqtt_retry_scheduled:
+                        _LOGGER.warning(
+                            "Could not connect to MQTT. Retry in %s seconds",
+                            MQTT_RECONNECT_INTERVAL_IN_SECONDS,
+                        )
+                        async_call_later(
+                            hass, MQTT_RECONNECT_INTERVAL_IN_SECONDS, _retry_mqtt
+                        )
+                        self._mqtt_retry_scheduled = True
 
             async_at_started(
                 hass=self.hass, at_start_cb=_async_finish_startup


### PR DESCRIPTION
Implements a 5 minute retry loop when the first MQTT connection fails.

Fixes #949 