### PR TITLE
fix: improve handling of error responses coming from myskoda

### DIFF
--- a/custom_components/myskoda/button.py
+++ b/custom_components/myskoda/button.py
@@ -18,6 +18,8 @@ from homeassistant.exceptions import ServiceValidationError
 from myskoda.models.info import CapabilityId
 from myskoda.mqtt import OperationFailedError
 
+from aiohttp import ClientResponseError
+
 from .const import API_COOLDOWN_IN_SECONDS, CONF_READONLY, COORDINATORS, DOMAIN
 from .coordinator import MySkodaConfigEntry, MySkodaDataUpdateCoordinator
 from .entity import MySkodaEntity
@@ -107,7 +109,7 @@ class HonkFlash(MySkodaButton):
         myskoda, vin = self.coordinator.myskoda, self.vehicle.info.vin
         try:
             await self._press_button(myskoda.honk_flash(vin))
-        except OperationFailedError as exc:
+        except (ClientResponseError, OperationFailedError) as exc:
             _LOGGER.error("Failed honk and flash: %s", exc)
         _LOGGER.info("Sent honk and flash")
 
@@ -130,7 +132,7 @@ class Flash(MySkodaButton):
         myskoda, vin = self.coordinator.myskoda, self.vehicle.info.vin
         try:
             await self._press_button(myskoda.flash(vin))
-        except OperationFailedError as exc:
+        except (ClientResponseError, OperationFailedError) as exc:
             _LOGGER.error("Failed to flash lights: %s", exc)
         _LOGGER.info("Sent light flash")
 
@@ -159,7 +161,7 @@ class WakeUp(MySkodaButton):
         myskoda, vin = self.coordinator.myskoda, self.vehicle.info.vin
         try:
             await self._press_button(myskoda.wakeup(vin))
-        except OperationFailedError as exc:
+        except (ClientResponseError, OperationFailedError) as exc:
             _LOGGER.error("Failed to wake up vehicle: %s", exc)
         _LOGGER.info("Signaled vehicle to wake up")
 

--- a/custom_components/myskoda/climate.py
+++ b/custom_components/myskoda/climate.py
@@ -23,6 +23,8 @@ from homeassistant.helpers.typing import (
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.util import Throttle
 
+from aiohttp import ClientResponseError
+
 from myskoda.models.air_conditioning import (
     AirConditioning,
     AirConditioningState,
@@ -247,7 +249,7 @@ class MySkodaClimate(MySkodaClimateEntity):
                 _LOGGER.info("Auxiliary heating detected, stopping first.")
                 try:
                     await self._stop_auxiliary_heating()
-                except OperationFailedError as exc:
+                except (ClientResponseError, OperationFailedError) as exc:
                     self._unset_optimistic_data(OptimisticAttribute.HVAC_MODE)
                     _LOGGER.error("Failed to stop aux heater, aborting action: %s", exc)
                     return
@@ -255,7 +257,7 @@ class MySkodaClimate(MySkodaClimateEntity):
             try:
                 await self._start_air_conditioning(target_temperature.temperature_value)
 
-            except OperationFailedError as exc:
+            except (ClientResponseError, OperationFailedError) as exc:
                 self._unset_optimistic_data(OptimisticAttribute.HVAC_MODE)
                 _LOGGER.error("Failed to start air conditioning: %s", exc)
 
@@ -263,7 +265,7 @@ class MySkodaClimate(MySkodaClimateEntity):
             _LOGGER.info("Stopping Air conditioning.")
             try:
                 await self._stop_air_conditioning()
-            except OperationFailedError as exc:
+            except (ClientResponseError, OperationFailedError) as exc:
                 _LOGGER.error("Failed to stop air conditioning: %s", exc)
         _LOGGER.info("HVAC mode set to %s.", hvac_mode)
 
@@ -286,7 +288,7 @@ class MySkodaClimate(MySkodaClimateEntity):
         try:
             await self._set_target_temperature(temp)
             _LOGGER.info("Target temperature set to %s.", temp)
-        except OperationFailedError as exc:
+        except (ClientResponseError, OperationFailedError) as exc:
             self._unset_optimistic_data(OptimisticAttribute.TARGET_TEMPERATURE)
             _LOGGER.error("Failed to set target temperature: %s", exc)
 
@@ -445,7 +447,7 @@ class AuxiliaryHeater(MySkodaClimateEntity):
                 _LOGGER.info("%s mode detected, stopping first.", state)
                 try:
                     await self._stop_air_conditioning()
-                except OperationFailedError as exc:
+                except (ClientResponseError, OperationFailedError) as exc:
                     self._unset_optimistic_data(OptimisticAttribute.HVAC_MODE)
                     _LOGGER.error("Failed to stop air conditioning: %s", exc)
                     return
@@ -464,7 +466,7 @@ class AuxiliaryHeater(MySkodaClimateEntity):
             _LOGGER.info("Starting %s [%s]", start_mode or "heating", config)
             try:
                 await self._start_auxiliary_heating(spin=spin, config=config)
-            except OperationFailedError as exc:
+            except (ClientResponseError, OperationFailedError) as exc:
                 self._unset_optimistic_data(OptimisticAttribute.HVAC_MODE)
                 _LOGGER.error("Failed to start aux heating: %s", exc)
 
@@ -489,7 +491,7 @@ class AuxiliaryHeater(MySkodaClimateEntity):
                 _LOGGER.info("Stopping Auxiliary heater.")
                 try:
                     await self._stop_auxiliary_heating()
-                except OperationFailedError as exc:
+                except (ClientResponseError, OperationFailedError) as exc:
                     _LOGGER.error("Failed to stop aux heater: %s", exc)
 
         _LOGGER.info("Auxiliary HVAC mode set to %s.", hvac_mode)

--- a/custom_components/myskoda/lock.py
+++ b/custom_components/myskoda/lock.py
@@ -14,6 +14,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import DiscoveryInfoType  # pyright: ignore [reportAttributeAccessIssue]
 from homeassistant.util import Throttle
 
+from aiohttp import ClientResponseError
+
 from myskoda.models.common import DoorLockedState
 from myskoda.models.info import CapabilityId
 from myskoda.mqtt import OperationFailedError
@@ -113,7 +115,7 @@ class DoorLock(MySkodaLock):
                 await self._operate_lock(myskoda.lock(vin, spin))
             else:
                 await self._operate_lock(myskoda.unlock(vin, spin))
-        except OperationFailedError as exc:
+        except (ClientResponseError, OperationFailedError) as exc:
             _LOGGER.error("Failed to unlock vehicle: %s", exc)
 
     async def async_lock(self, **kwargs) -> None:

--- a/custom_components/myskoda/number.py
+++ b/custom_components/myskoda/number.py
@@ -18,6 +18,8 @@ from homeassistant.helpers.typing import DiscoveryInfoType  # pyright: ignore [r
 from homeassistant.util import Throttle
 from homeassistant.exceptions import ServiceValidationError
 
+from aiohttp import ClientResponseError
+
 from myskoda.models.info import CapabilityId
 from myskoda.mqtt import OperationFailedError
 
@@ -124,7 +126,7 @@ class ChargeLimit(MySkodaNumber):
         myskoda, vin = self.coordinator.myskoda, self.vehicle.info.vin
         try:
             await self._change_number(myskoda.set_charge_limit(vin, int(value)))
-        except OperationFailedError as exc:
+        except (ClientResponseError, OperationFailedError) as exc:
             _LOGGER.error("Failed to set charging limit: %s", exc)
         _LOGGER.info("Set charging limit to %s", int(value))
 

--- a/custom_components/myskoda/switch.py
+++ b/custom_components/myskoda/switch.py
@@ -16,6 +16,8 @@ from homeassistant.helpers.typing import DiscoveryInfoType  # pyright: ignore [r
 from homeassistant.util import Throttle
 from homeassistant.exceptions import ServiceValidationError
 
+from aiohttp import ClientResponseError
+
 from myskoda.models.charging import (
     Charging,
     ChargingState,
@@ -150,7 +152,7 @@ class WindowHeatingSwitch(MySkodaSwitch):
                 await self._flip_switch(myskoda.start_window_heating(vin))
             else:
                 await self._flip_switch(myskoda.stop_window_heating(vin))
-        except OperationFailedError as exc:
+        except (ClientResponseError, OperationFailedError) as exc:
             _LOGGER.error("Failed to turn window heating %s: %s", action, exc)
         _LOGGER.info("Window heating successfully turned %s", action)
 
@@ -217,7 +219,7 @@ class BatteryCareMode(ChargingSwitch):
                 await self._flip_switch(myskoda.set_battery_care_mode(vin, True))
             else:
                 await self._flip_switch(myskoda.set_battery_care_mode(vin, False))
-        except OperationFailedError as exc:
+        except (ClientResponseError, OperationFailedError) as exc:
             _LOGGER.error("Failed to turn battery care mode %s: %s", action, exc)
         _LOGGER.info("Battery care mode successfully turned %s", action)
 
@@ -254,7 +256,7 @@ class ReducedCurrent(ChargingSwitch):
         action = "on" if turn_on else "off"
         try:
             await self._flip_switch(myskoda.set_reduced_current_limit(vin, turn_on))
-        except OperationFailedError as exc:
+        except (ClientResponseError, OperationFailedError) as exc:
             _LOGGER.error("Failed to turn reduced current limit %s: %s", action, exc)
         _LOGGER.info("Reduced current limit successfully turned %s", action)
 
@@ -290,7 +292,7 @@ class EnableCharging(ChargingSwitch):
                 await self._flip_switch(myskoda.start_charging(vin))
             else:
                 await self._flip_switch(myskoda.stop_charging(vin))
-        except OperationFailedError as exc:
+        except (ClientResponseError, OperationFailedError) as exc:
             _LOGGER.error("Failed to turn charging heating %s: %s", action, exc)
         _LOGGER.info("Charging successfully turned %s", action)
 
@@ -324,7 +326,7 @@ class AutoUnlockPlug(ChargingSwitch):
         action = "on" if turn_on else "off"
         try:
             await self._flip_switch(myskoda.set_auto_unlock_plug(vin, turn_on))
-        except OperationFailedError as exc:
+        except (ClientResponseError, OperationFailedError) as exc:
             _LOGGER.error("Failed to turn auto unlock plug %s: %s", action, exc)
         _LOGGER.info("Auto unlock plug successfully turned %s", action)
 
@@ -363,7 +365,7 @@ class AcAtUnlock(MySkodaSwitch):
         action = "on" if turn_on else "off"
         try:
             await self._flip_switch(myskoda.set_ac_at_unlock(vin, settings))
-        except OperationFailedError as exc:
+        except (ClientResponseError, OperationFailedError) as exc:
             _LOGGER.error("Failed to turn AC at Unlock %s: %s", action, exc)
         _LOGGER.info("AC at Unlock successfully turned %s", action)
 
@@ -406,7 +408,7 @@ class AcWithoutExternalPower(MySkodaSwitch):
             await self._flip_switch(
                 myskoda.set_ac_without_external_power(vin, settings)
             )
-        except OperationFailedError as exc:
+        except (ClientResponseError, OperationFailedError) as exc:
             _LOGGER.error(
                 "Failed to turn AC without external power %s: %s", action, exc
             )
@@ -450,7 +452,7 @@ class AcSeatHeatingFrontLeft(MySkodaSwitch):
         action = "on" if turn_on else "off"
         try:
             await self._flip_switch(myskoda.set_seats_heating(vin, settings))
-        except OperationFailedError as exc:
+        except (ClientResponseError, OperationFailedError) as exc:
             _LOGGER.error(
                 "Failed to turn frontLeft seat heating with AC %s: %s", action, exc
             )
@@ -494,7 +496,7 @@ class AcSeatHeatingFrontRight(MySkodaSwitch):
         action = "on" if turn_on else "off"
         try:
             await self._flip_switch(myskoda.set_seats_heating(vin, settings))
-        except OperationFailedError as exc:
+        except (ClientResponseError, OperationFailedError) as exc:
             _LOGGER.error(
                 "Failed to turn frontright seat heating with AC %s: %s", action, exc
             )
@@ -535,7 +537,7 @@ class AcWindowHeating(MySkodaSwitch):
         action = "on" if turn_on else "off"
         try:
             await self._flip_switch(myskoda.set_windows_heating(vin, settings))
-        except OperationFailedError as exc:
+        except (ClientResponseError, OperationFailedError) as exc:
             _LOGGER.error("Failed to turn window heating with AC %s: %s", action, exc)
         _LOGGER.info("Window heating with AC successfully turned %s", action)
 
@@ -592,7 +594,7 @@ class DepartureTimerSwitch(MySkodaSwitch):
             timer.enabled = turn_on
             try:
                 await self._flip_switch(myskoda.set_departure_timer(self.vin, timer))
-            except OperationFailedError as exc:
+            except (ClientResponseError, OperationFailedError) as exc:
                 _LOGGER.error(
                     "Failed to turn Departure Timer %s %s: %s",
                     self.timer_id,
@@ -711,7 +713,7 @@ class ACTimerSwitch(MySkodaSwitch):
             timer.enabled = turn_on
             try:
                 await self._flip_switch(myskoda.set_ac_timer(self.vin, timer))
-            except OperationFailedError as exc:
+            except (ClientResponseError, OperationFailedError) as exc:
                 _LOGGER.error(
                     "Failed to turn AirConditioning timer %s %s: %s",
                     self.timer_id,


### PR DESCRIPTION
This improves handling of error-states coming back from the myskoda api endpoints by generically catching the `ClientResponseError` 

Fixes #1028