### PR TITLE
chore(deps): bump myskoda from 2.8.0 to 2.9.1

### DIFF
--- a/custom_components/myskoda/manifest.json
+++ b/custom_components/myskoda/manifest.json
@@ -17,7 +17,7 @@
     "myskoda"
   ],
   "requirements": [
-    "myskoda==2.8.0"
+    "myskoda==2.9.1"
   ],
   "version": "1.31.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.13.2"
-dependencies = ["homeassistant>=2025.10.2", "myskoda>=2.8.0"]
+dependencies = ["homeassistant>=2025.10.2", "myskoda>=2.9.1"]
 
 [dependency-groups]
 dev = ["homeassistant-stubs>=2025.10.2", "ruff ~=0.15.0", "pyright ~=1.1.400"]

--- a/uv.lock
+++ b/uv.lock
@@ -831,6 +831,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/77/2a/581b3808afec55b2db838742527c40b4ce68b9b64feedff0fd0123f4b19a/greenlet-3.2.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:e1967882f0c42eaf42282a87579685c8673c51153b845fde1ee81be720ae27ac", size = 269119, upload-time = "2025-04-22T14:25:01.798Z" },
     { url = "https://files.pythonhosted.org/packages/b0/f3/1c4e27fbdc84e13f05afc2baf605e704668ffa26e73a43eca93e1120813e/greenlet-3.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e77ae69032a95640a5fe8c857ec7bee569a0997e809570f4c92048691ce4b437", size = 637314, upload-time = "2025-04-22T14:53:46.214Z" },
     { url = "https://files.pythonhosted.org/packages/fc/1a/9fc43cb0044f425f7252da9847893b6de4e3b20c0a748bce7ab3f063d5bc/greenlet-3.2.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3227c6ec1149d4520bc99edac3b9bc8358d0034825f3ca7572165cb502d8f29a", size = 651421, upload-time = "2025-04-22T14:55:00.852Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/65/d47c03cdc62c6680206b7420c4a98363ee997e87a5e9da1e83bd7eeb57a8/greenlet-3.2.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ddda0197c5b46eedb5628d33dad034c455ae77708c7bf192686e760e26d6a0c", size = 645789, upload-time = "2025-04-22T15:04:37.702Z" },
     { url = "https://files.pythonhosted.org/packages/2f/40/0faf8bee1b106c241780f377b9951dd4564ef0972de1942ef74687aa6bba/greenlet-3.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de62b542e5dcf0b6116c310dec17b82bb06ef2ceb696156ff7bf74a7a498d982", size = 648262, upload-time = "2025-04-22T14:27:07.55Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a8/73305f713183c2cb08f3ddd32eaa20a6854ba9c37061d682192db9b021c3/greenlet-3.2.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c07a0c01010df42f1f058b3973decc69c4d82e036a951c3deaf89ab114054c07", size = 606770, upload-time = "2025-04-22T14:25:58.34Z" },
     { url = "https://files.pythonhosted.org/packages/c3/05/7d726e1fb7f8a6ac55ff212a54238a36c57db83446523c763e20cd30b837/greenlet-3.2.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:2530bfb0abcd451ea81068e6d0a1aac6dabf3f4c23c8bd8e2a8f579c2dd60d95", size = 1117960, upload-time = "2025-04-22T14:59:00.373Z" },
@@ -838,6 +839,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/f6/339c6e707062319546598eb9827d3ca8942a3eccc610d4a54c1da7b62527/greenlet-3.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:24a496479bc8bd01c39aa6516a43c717b4cee7196573c47b1f8e1011f7c12495", size = 295994, upload-time = "2025-04-22T14:50:44.796Z" },
     { url = "https://files.pythonhosted.org/packages/f1/72/2a251d74a596af7bb1717e891ad4275a3fd5ac06152319d7ad8c77f876af/greenlet-3.2.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:175d583f7d5ee57845591fc30d852b75b144eb44b05f38b67966ed6df05c8526", size = 629889, upload-time = "2025-04-22T14:53:48.434Z" },
     { url = "https://files.pythonhosted.org/packages/29/2e/d7ed8bf97641bf704b6a43907c0e082cdf44d5bc026eb8e1b79283e7a719/greenlet-3.2.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3ecc9d33ca9428e4536ea53e79d781792cee114d2fa2695b173092bdbd8cd6d5", size = 635261, upload-time = "2025-04-22T14:55:02.258Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/802aa27848a6fcb5e566f69c64534f572e310f0f12d41e9201a81e741551/greenlet-3.2.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3f56382ac4df3860ebed8ed838f268f03ddf4e459b954415534130062b16bc32", size = 632523, upload-time = "2025-04-22T15:04:39.221Z" },
     { url = "https://files.pythonhosted.org/packages/56/09/f7c1c3bab9b4c589ad356503dd71be00935e9c4db4db516ed88fc80f1187/greenlet-3.2.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc45a7189c91c0f89aaf9d69da428ce8301b0fd66c914a499199cfb0c28420fc", size = 628816, upload-time = "2025-04-22T14:27:08.869Z" },
     { url = "https://files.pythonhosted.org/packages/79/e0/1bb90d30b5450eac2dffeaac6b692857c4bd642c21883b79faa8fa056cf2/greenlet-3.2.1-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51a2f49da08cff79ee42eb22f1658a2aed60c72792f0a0a95f5f0ca6d101b1fb", size = 593687, upload-time = "2025-04-22T14:25:59.676Z" },
     { url = "https://files.pythonhosted.org/packages/c5/b5/adbe03c8b4c178add20cc716021183ae6b0326d56ba8793d7828c94286f6/greenlet-3.2.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:0c68bbc639359493420282d2f34fa114e992a8724481d700da0b10d10a7611b8", size = 1105754, upload-time = "2025-04-22T14:59:02.585Z" },
@@ -1035,7 +1037,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2025.10.2" },
-    { name = "myskoda", specifier = ">=2.8.0" },
+    { name = "myskoda", specifier = ">=2.9.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -1241,7 +1243,7 @@ wheels = [
 
 [[package]]
 name = "myskoda"
-version = "2.8.0"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1250,9 +1252,9 @@ dependencies = [
     { name = "pyjwt" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/da/bc5a6e465e6b21d1ab457f6e0fafdf8719fe4c0dafa4c24a3cd360fbb5cb/myskoda-2.8.0.tar.gz", hash = "sha256:bb718c59d625a79ab6de3e5993ef05802038a53a31851c86fbf185d1da3cd0bd", size = 350208, upload-time = "2026-03-22T17:44:33.525Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/38/2226f5238900c722384cd45f2768649ca157d7d29654cdc39fb4f838bd37/myskoda-2.9.1.tar.gz", hash = "sha256:98ac1e1a611ecd8342a8c793b2f8fd99a4682db1d9d885b9b21565778801dc57", size = 352908, upload-time = "2026-03-30T14:02:26.051Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/3c/2da7da030420405d0a8c84b7569298cd9cbee8ebf60d8dbf6dd35d4d1038/myskoda-2.8.0-py3-none-any.whl", hash = "sha256:b18c0554b64cd526460fb518304765a35fd1b2208b0d5e7478e6d4420cd3b17b", size = 71246, upload-time = "2026-03-22T17:44:32.547Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cc/8f16d06bda6df573146f462fa169213d324bfc025bc8319dffd47ca52919/myskoda-2.9.1-py3-none-any.whl", hash = "sha256:d8989f69eb0e3b02931ae133c4e483ed29f489c62fca9280157dfb6dfbf448b8", size = 73033, upload-time = "2026-03-30T14:02:24.85Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What's Changed
### ✨ New features
* feat: add support of driving-score endpoint by @moledzki in https://github.com/skodaconnect/myskoda/pull/540
* feat: add support for software-version/update-status endpoint by @WebSpider in https://github.com/skodaconnect/myskoda/pull/541
### 🐛 Bugfixes
* fix: DrivingScore was not using BaseResponse as parent class by @moledzki in https://github.com/skodaconnect/myskoda/pull/544
### 🛠️ Dependencies
* chore(deps-dev): bump pytest-cov from 7.0.0 to 7.1.0 by @dependabot[bot] in https://github.com/skodaconnect/myskoda/pull/539
* chore(deps-dev): bump ruff from 0.15.7 to 0.15.8 by @dependabot[bot] in https://github.com/skodaconnect/myskoda/pull/542
* chore(deps): bump pygments from 2.19.2 to 2.20.0 by @dependabot[bot] in https://github.com/skodaconnect/myskoda/pull/545
* chore(deps): bump aiohttp from 3.13.3 to 3.13.4 by @dependabot[bot] in https://github.com/skodaconnect/myskoda/pull/546
* chore(deps): relax dependencies to indicate minimal required versions by @WebSpider in https://github.com/skodaconnect/myskoda/pull/549

**Full Changelog**: https://github.com/skodaconnect/myskoda/compare/v2.8.0...v2.9.1