### PR TITLE
fix: use updates models for image renders

### DIFF
--- a/custom_components/myskoda/device_tracker.py
+++ b/custom_components/myskoda/device_tracker.py
@@ -9,10 +9,12 @@ from homeassistant.components.device_tracker.config_entry import (
 from homeassistant.components.device_tracker.const import SourceType
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import DiscoveryInfoType  # pyright: ignore [reportAttributeAccessIssue]
+from homeassistant.helpers.typing import (
+    DiscoveryInfoType,  # pyright: ignore [reportAttributeAccessIssue]
+)
 
 from myskoda.models.charging import Charging, ChargingStatus
-from myskoda.models.info import CapabilityId
+from myskoda.models.info import CapabilityId, ViewPoint, ViewType
 from myskoda.models.position import (
     Error,
     ErrorType,
@@ -120,26 +122,20 @@ class DeviceTracker(MySkodaEntity, TrackerEntity):
         if pp := self._parking_position():
             attributes["parking_address"] = pp.formatted_address
 
-        if render := self.get_renders().get("main"):
+        if render := self.get_renders().get(ViewPoint.MAIN):
             attributes["entity_picture"] = render
-        elif render := self.get_composite_renders().get("unmodified_exterior_front"):
+        elif renders := self.get_composite_renders().get(
+            ViewType.UNMODIFIED_EXTERIOR_FRONT
+        ):
             _LOGGER.debug("Main render not found, choosing composite render instead.")
-            render_list = self.get_composite_renders().get("unmodified_exterior_front")
-            if isinstance(render_list, list) and render_list:
-                for render in render_list:
-                    if isinstance(render, dict) and "exterior_front" in render:
-                        attributes["entity_picture"] = render["exterior_front"]
-                        break
-        else:
+            attributes["entity_picture"] = renders.get(ViewPoint.EXTERIOR_FRONT)
+        elif renders := self.get_composite_renders().get(
+            ViewType.UNMODIFIED_EXTERIOR_SIDE
+        ):
             _LOGGER.debug(
                 "'unmodified_exterior_front' not found, falling back to 'unmodified_exterior_side'."
             )
-            render_list = self.get_composite_renders().get("unmodified_exterior_side")
-            if isinstance(render_list, list) and render_list:
-                for render in render_list:
-                    if isinstance(render, dict) and "exterior_side" in render:
-                        attributes["entity_picture"] = render["exterior_side"]
-                        break
+            attributes["entity_picture"] = renders.get(ViewPoint.EXTERIOR_SIDE)
         return attributes
 
     @property

--- a/custom_components/myskoda/entity.py
+++ b/custom_components/myskoda/entity.py
@@ -5,7 +5,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from myskoda import Vehicle
 from myskoda.models.event import OperationEvent
-from myskoda.models.info import CapabilityId
+from myskoda.models.info import CapabilityId, ViewPoint, ViewType
 
 from .const import DOMAIN
 from .coordinator import (
@@ -79,7 +79,7 @@ class MySkodaEntity(CoordinatorEntity):
         """Check if all capabilities in the list are supported."""
         return all(self.vehicle.has_capability(capability) for capability in cap)
 
-    def get_renders(self) -> dict[str, str]:
+    def get_renders(self) -> dict[ViewPoint, str]:
         """Return a dict of all vehicle image render URLs, keyed by view_point.
 
         E.g.
@@ -87,18 +87,16 @@ class MySkodaEntity(CoordinatorEntity):
         """
         return {render.view_point: render.url for render in self.vehicle.info.renders}
 
-    def get_composite_renders(self) -> dict[str, list[dict[str, str]]]:
-        """Return a dict of all vehicle composite render URLs, keyed by view_type, lower cased.
-        Value contains a list of available renders, keyed by view_point.
+    def get_composite_renders(self) -> dict[ViewType, dict[ViewPoint, str]]:
+        """Return a dict of all vehicle composite render URLs, keyed by view_type.
+        Value contains a dict of available renders, keyed by view_point.
 
         E.g.
-        {"home": [ {"exterior_side": "https://ip-modcwp.azureedge.net/path/render.png"} ] }
+        {"home": {"exterior_side": "https://ip-modcwp.azureedge.net/path/render.png"}}
         """
         composite_renders = {}
         for cr in self.vehicle.info.composite_renders:
-            composite_renders[cr.view_type.lower()] = []
-            for render in cr.layers:
-                composite_renders[cr.view_type.lower()].append(
-                    {render.view_point: render.url}
-                )
+            composite_renders[cr.view_type] = {
+                render.view_point: render.url for render in cr.layers
+            }
         return composite_renders

--- a/custom_components/myskoda/image.py
+++ b/custom_components/myskoda/image.py
@@ -1,19 +1,23 @@
 """Images for the MySkoda integration."""
 
-import httpx
 import logging
 
+import httpx
 from homeassistant.components.image import (
+    GET_IMAGE_TIMEOUT,
     ImageEntity,
     ImageEntityDescription,
-    GET_IMAGE_TIMEOUT,
 )
 from homeassistant.const import (
     EntityCategory,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import DiscoveryInfoType  # pyright: ignore [reportAttributeAccessIssue]
+from homeassistant.helpers.typing import (
+    DiscoveryInfoType,  # pyright: ignore [reportAttributeAccessIssue]
+)
+
+from myskoda.models.info import ViewPoint, ViewType
 
 from .const import COORDINATORS, DOMAIN
 from .coordinator import MySkodaConfigEntry, MySkodaDataUpdateCoordinator
@@ -115,25 +119,20 @@ class MainRenderImage(MySkodaImage):
 
     @property
     def image_url(self) -> str | None:
-        if render := self.get_renders().get("main"):
+        if render := self.get_renders().get(ViewPoint.MAIN):
             return render
-        elif render := self.get_composite_renders().get("unmodified_exterior_front"):
+        elif renders := self.get_composite_renders().get(
+            ViewType.UNMODIFIED_EXTERIOR_FRONT
+        ):
             _LOGGER.debug("Main render not found, choosing composite render instead.")
-            render_list = self.get_composite_renders().get("unmodified_exterior_front")
-            if isinstance(render_list, list) and render_list:
-                for render in render_list:
-                    if isinstance(render, dict) and "exterior_front" in render:
-                        return render["exterior_front"]
-
-        else:
+            return renders.get(ViewPoint.EXTERIOR_FRONT)
+        elif renders := self.get_composite_renders().get(
+            ViewType.UNMODIFIED_EXTERIOR_SIDE
+        ):
             _LOGGER.debug(
                 "'unmodified_exterior_front' not found, falling back to 'unmodified_exterior_side'."
             )
-            render_list = self.get_composite_renders().get("unmodified_exterior_side")
-            if isinstance(render_list, list) and render_list:
-                for render in render_list:
-                    if isinstance(render, dict) and "exterior_side" in render:
-                        return render["exterior_side"]
+            return renders.get(ViewPoint.EXTERIOR_SIDE)
 
     @property
     def extra_state_attributes(self) -> dict:


### PR DESCRIPTION
Uptake changes from https://github.com/skodaconnect/myskoda/commit/35a855f8b7b927ca0c51eda3ef9c22c01274104a

Simplify get_composite_renders()

Fixes: #1084

Draft: need to review where else `get_renders()` and `get_composite_renders()` are used and update accordingly. Not really convinced we actually need these helpers vs just using the models directly.

Also need to figure out why my entity status is still Unknown. The image is back though...
<img width="304" height="46" alt="image" src="https://github.com/user-attachments/assets/99d90555-7145-4fca-bdd9-fe67cbbf449a" />
