### PR TITLE
fix: store ServiceEventData as dict

### DIFF
--- a/custom_components/myskoda/sensor.py
+++ b/custom_components/myskoda/sensor.py
@@ -2,6 +2,7 @@
 
 from datetime import UTC, datetime
 from math import isnan
+from typing import Any
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -117,7 +118,7 @@ class Operation(MySkodaSensor):
             return last_operation.status.lower()
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Returns additional attributes for the operation sensor.
 
         - request_id, operation name, error_code and timestamp of the last seen operation.
@@ -163,7 +164,7 @@ class ServiceEvent(MySkodaSensor):
             return last_service_event.timestamp
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Returns additional attributes for the service event sensor.
 
         - history: a list of dicts with the same fields for the previously seen event.
@@ -176,7 +177,7 @@ class ServiceEvent(MySkodaSensor):
             {
                 "name": event.name.value,
                 "timestamp": event.timestamp,
-                "data": event.data,
+                "data": event.data.to_dict(),
             }
             for event in self.service_events
         ]


### PR DESCRIPTION
We shouldn't pass internal MySkoda dataclass/mashumaro models down into HA as this can cause issues. For e.g. when attempting to serialize entity state changes to JSON using the mqtt_statestream integration.

(`datetime` objects are already handled by [HA's JSON encoder](https://github.com/home-assistant/core/blob/5858db1cda37f7fe8f68cc9130464f0c2bc68b15/homeassistant/helpers/json.py#L53))

Fixes #639