### PR TITLE
docs: deprecate device_tracker vehicle_in_motion state

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,13 +223,10 @@ Refer to [docs/design.md](docs/design.md).
 ## FAQ
 
 #### Is there a sensor to indicate the vehicle is moving?
-There is not but the device tracker will report `vehicle_in_motion`. If you need a binary sensor you can create a [template sensor](https://www.home-assistant.io/integrations/template/). Example:
 
-```python
-{% if states('device_tracker.skoda_enyaq_position') == 'vehicle_in_motion' %}
-True
-{% endif %}
-```
+Yes. Use the `binary_sensor.<vehicle>_in_motion` entity.
+
+> **Deprecated:** Checking the device tracker state against `vehicle_in_motion` is deprecated and will be removed in a future release. Use the binary sensor instead.
 
 #### Why does toggling a switch make it unavailable?
 See [Operations](#operations-switches-buttons-and-numbers).

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -166,9 +166,18 @@ Number entities become temporarily unavailable when modified, until the API oper
 
 | Key              | Name     | Capability required | Notes                                                      |
 |------------------|----------|---------------------|------------------------------------------------------------|
-| `device_tracker` | Position | PARKING_POSITION    | Reports `vehicle_in_motion` state while the vehicle is moving |
+| `device_tracker` | Position | PARKING_POSITION    | Reports deprecated `vehicle_in_motion` state while the vehicle is moving |
 
 Location is exposed as a device tracker. While the vehicle is moving the Skoda API does not return GPS coordinates; the tracker will report the `vehicle_in_motion` state instead of a location.
+
+> **Deprecated:** Checking `vehicle_in_motion` as the tracker state is deprecated. Use `binary_sensor.<vehicle>_in_motion` instead.
+
+The entity exposes the following extra state attributes:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `parking_address` | `string` | Formatted address of the last known parking location |
+| `entity_picture` | `string` | URL of the vehicle render image |
 
 ---
 


### PR DESCRIPTION
This deprecates the `vehicle_in_motion` state of the `device_tracker` in favour of the `binary_sensor.<vehicle>_in_motion`

There is no actual code being changed there, it is just a documentation update.
Related to #1098 