### PR TITLE
chore(ci): split uv dependabot entry to lock dev deps to lockfile-only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,23 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    allow:
+      - dependency-type: "production"
     ignore:
       # Dependabot should not update Home Assistant as that should match the homeassistant key in hacs.json
       - dependency-name: "homeassistant"
+    labels:
+      - dependencies
+      - ignore-for-release
+      - python:uv
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    versioning-strategy: lockfile-only
+    allow:
+      - dependency-type: "development"
     labels:
       - dependencies
       - ignore-for-release


### PR DESCRIPTION
Prevent dependabot from bumping version constraints in `pyproject.toml` for dev dependencies (ruff, pyright, homeassistant-stubs).