### PR TITLE
fix: resolve HA2026.06 warning for device_tracker

### DIFF
--- a/custom_components/myskoda/device_tracker.py
+++ b/custom_components/myskoda/device_tracker.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from homeassistant.components.device_tracker.config_entry import (
+from homeassistant.components.device_tracker import (
     TrackerEntity,
     TrackerEntityDescription,
 )


### PR DESCRIPTION
This resolves an import warning that started appearing on HA 2026.06. The fix is backwards compatible to 2022, so we do not need to update the compatibility matrix.

Note: When we resolve this, a new warning will appear about the `location_name` property of the `device_tracker`. This warning is correct and will be addressed in a future release

Fixes #1116 
Related-to: #1098 