### PR TITLE
fix: delegate get_software_update_status to MySkoda

### DIFF
--- a/custom_components/myskoda/coordinator.py
+++ b/custom_components/myskoda/coordinator.py
@@ -183,15 +183,6 @@ class MySkodaDataUpdateCoordinator(DataUpdateCoordinator[State]):
                 )
                 raise UpdateFailed("Failed to retrieve initial data during setup")
 
-            try:
-                vehicle.software_update_status = (
-                    await self.myskoda.get_software_update_status(self.vin)
-                )
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.debug(
-                    "Software update status not available for %s: %s", self.vin, err
-                )
-
             async def _async_finish_startup(hass: HomeAssistant) -> None:
                 """Tasks to execute when we have finished starting up."""
                 _LOGGER.debug(


### PR DESCRIPTION
Fixes #1134

The
`api/v1/vehicle-information/TMBXXXXXXXXXXXXXX/software-version/update-status` endpoint is (presumably) only available for MEB platform vehicles. And returns a blank HTTP 500 for other vehicles.

Rather than having the integration deal with this (see skodaconnect/homeassistant-myskoda#1114) have MySkoda handles this like other capabilities. This is implemented in https://github.com/skodaconnect/myskoda/pull/613