### PR TITLE
fix: add position fallback to motion-detection binary sensor

### DIFF
--- a/custom_components/myskoda/binary_sensor.py
+++ b/custom_components/myskoda/binary_sensor.py
@@ -436,7 +436,7 @@ class VehicleInMotion(VehicleConnectionBinarySensor):
     )
 
     def _positions(self) -> Positions | None:
-        if vehicle_positions := self.vehicle.positions
+        if vehicle_positions := self.vehicle.positions:
             return vehicle_positions
 
     def _motion_detection(self) -> Error | None:

--- a/custom_components/myskoda/binary_sensor.py
+++ b/custom_components/myskoda/binary_sensor.py
@@ -20,6 +20,12 @@ from myskoda.models.common import (
 )
 from myskoda.models.info import CapabilityId
 from myskoda.models.status import DoorWindowState, Status
+from myskoda.models.position import (
+    Error,
+    ErrorType,
+    Positions,
+)
+
 from myskoda.models.vehicle_connection_status import VehicleConnectionStatus
 
 from .coordinator import MySkodaConfigEntry

--- a/custom_components/myskoda/binary_sensor.py
+++ b/custom_components/myskoda/binary_sensor.py
@@ -435,10 +435,28 @@ class VehicleInMotion(VehicleConnectionBinarySensor):
         translation_key="vehicle_in_motion",
     )
 
+    def _positions(self) -> Positions | None:
+        if vehicle_positions := self.vehicle.positions
+            return vehicle_positions
+
+    def _motion_detection(self) -> Error | None:
+        if pos := self._positions():
+            if pos.errors:
+                return next(
+                    err for err in pos.errors if err.type == ErrorType.VEHICLE_IN_MOTION
+                )
+
     @property
     def is_on(self) -> bool | None:
         if cs := self._connection_status():
             return cs.in_motion
+        if motion_error := self._motion_detection():
+            return motion_error.type == ErrorType.VEHICLE_IN_MOTION
+
+    def is_supported(self) -> bool:  # noqa: D102
+        return self.has_any_capability(
+            [CapabilityId.PARKING_POSITION, CapabilityId.READINESS]
+        )
 
 
 class VehicleBatteryProtection(VehicleConnectionBinarySensor):

--- a/custom_components/myskoda/binary_sensor.py
+++ b/custom_components/myskoda/binary_sensor.py
@@ -458,6 +458,8 @@ class VehicleInMotion(VehicleConnectionBinarySensor):
             return cs.in_motion
         if motion_error := self._motion_detection():
             return motion_error.type == ErrorType.VEHICLE_IN_MOTION
+        if pos := self._positions:
+            return False
 
     def is_supported(self) -> bool:  # noqa: D102
         return self.has_any_capability(


### PR DESCRIPTION
This adds the logic for the old `device_tracker`'s movement detection to the new `binary_sensor` as a fallback and creates the sensor whenever the old `device_tracker` was able to detect movement.

Fixes #1132 