### PR TITLE
Remove battery_level property from device_tracker

### DIFF
--- a/custom_components/myskoda/device_tracker.py
+++ b/custom_components/myskoda/device_tracker.py
@@ -138,12 +138,5 @@ class DeviceTracker(MySkodaEntity, TrackerEntity):
             attributes["entity_picture"] = renders.get(ViewPoint.EXTERIOR_SIDE)
         return attributes
 
-    @property
-    def battery_level(self) -> int | None:
-        if self.has_all_capabilities([CapabilityId.CHARGING]):
-            if status := self._status():
-                if status.battery.state_of_charge_in_percent is not None:
-                    return min(status.battery.state_of_charge_in_percent, 100)
-
     def required_capabilities(self) -> list[CapabilityId]:
         return [CapabilityId.PARKING_POSITION]


### PR DESCRIPTION
As per https://developers.home-assistant.io/blog/2026/06/15/device-tracker-changes/:

The battery_level property has been deprecated in all device tracker base classes, and will stop working in Home Assistant Core 2027.7. Integrations should communicate battery level via a battery sensor instead.

mySkoda integration already uses seperate sensor (sensor.skoda_enyaq_battery_percentage)