### PR TITLE
fix: move author-note out of LICENSE header for SPDX detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,6 @@
 MIT License
 
-The names of the current MySkoda Authors can by found in the file pyproject.toml
-in the same directory as this LICENSE file.
-
-Copyright (c) 2025 The MySkoda Authors
+Copyright (c) 2026 The MySkoda Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -22,3 +19,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+The names of the current MySkoda Authors can be found in the file pyproject.toml
+in the same directory as this LICENSE file.


### PR DESCRIPTION
GitHub's licensee could not identify the license (SPDX: NOASSERTION) because extra text sat between the 'MIT License' header and the Copyright line. Moving the note to the bottom restores the standard MIT template so HACS validation passes.