### PR TITLE
feat(climate): add camping mode

### DIFF
--- a/custom_components/myskoda/climate.py
+++ b/custom_components/myskoda/climate.py
@@ -10,6 +10,7 @@ from homeassistant.components.climate import (
     ClimateEntityDescription,
 )
 from homeassistant.components.climate.const import (
+    PRESET_NONE,
     ClimateEntityFeature,
     HVACAction,
     HVACMode,
@@ -52,6 +53,8 @@ from .utils import add_supported_entities
 
 _LOGGER = logging.getLogger(__name__)
 
+PRESET_CAMPING = "camping"
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -72,6 +75,7 @@ class OptimisticAttribute(StrEnum):
     TARGET_TEMPERATURE = "target_temperature"
     HVAC_MODE = "hvac_mode"
     HVAC_ACTION = "hvac_action"
+    PRESET_MODE = "preset_mode"
 
 
 class MySkodaClimateEntity(MySkodaEntity, ClimateEntity):
@@ -168,6 +172,24 @@ class MySkodaClimateEntity(MySkodaEntity, ClimateEntity):
         finally:
             self._operation_in_progress = False
 
+    async def _start_camping(self, temperature: float) -> None:
+        self._ensure_not_readonly()
+        self._operation_in_progress = True
+        try:
+            await self.coordinator.myskoda.start_camping(
+                self.vehicle.info.vin, temperature
+            )
+        finally:
+            self._operation_in_progress = False
+
+    async def _stop_camping(self) -> None:
+        self._ensure_not_readonly()
+        self._operation_in_progress = True
+        try:
+            await self.coordinator.myskoda.stop_camping(self.vehicle.info.vin)
+        finally:
+            self._operation_in_progress = False
+
     async def _start_ventilation(self) -> None:
         self._ensure_not_readonly()
         self._operation_in_progress = True
@@ -209,15 +231,35 @@ class MySkodaClimate(MySkodaClimateEntity):
             [CapabilityId.ACTIVE_VENTILATION]
         ) and not self.has_all_capabilities([CapabilityId.AIR_CONDITIONING])
 
+    def _supports_camping(self) -> bool:
+        """Return True if the vehicle exposes camping mode."""
+        return (
+            self.has_all_capabilities([CapabilityId.CAMPING_MODE])
+            and not self._is_ventilation_only()
+        )
+
+    def _is_camping_active(self) -> bool:
+        """Return the current camping state (optimistic value first, then cached AC state)."""
+        if (
+            preset := self._optimistic_data.get(OptimisticAttribute.PRESET_MODE)
+        ) is not None:
+            return preset == PRESET_CAMPING
+        if (ac := self._air_conditioning()) and ac.camping_mode is not None:
+            return ac.camping_mode.enabled
+        return False
+
     @property
     def supported_features(self) -> ClimateEntityFeature:  # noqa: D102
         if self._is_ventilation_only():
             return ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TURN_OFF
-        return (
+        features = (
             ClimateEntityFeature.TARGET_TEMPERATURE
             | ClimateEntityFeature.TURN_ON
             | ClimateEntityFeature.TURN_OFF
         )
+        if self._supports_camping():
+            features |= ClimateEntityFeature.PRESET_MODE
+        return features
 
     @property
     def hvac_modes(self) -> list[HVACMode]:  # noqa: D102
@@ -255,6 +297,22 @@ class MySkodaClimate(MySkodaClimateEntity):
             if ac.state == AirConditioningState.VENTILATION:
                 return HVACAction.FAN
             return HVACAction.OFF
+
+    @property
+    def preset_modes(self) -> list[str] | None:  # noqa: D102
+        if self._supports_camping():
+            return [PRESET_NONE, PRESET_CAMPING]
+        return None
+
+    @property
+    def preset_mode(self) -> str | None:  # noqa: D102
+        if not self._supports_camping():
+            return None
+        if preset := self._optimistic_data.get(OptimisticAttribute.PRESET_MODE):
+            return preset
+        if (ac := self._air_conditioning()) and ac.camping_mode is not None:
+            return PRESET_CAMPING if ac.camping_mode.enabled else PRESET_NONE
+        return PRESET_NONE
 
     @property
     def target_temperature(self) -> None | float:  # noqa: D102
@@ -311,11 +369,23 @@ class MySkodaClimate(MySkodaClimateEntity):
             except (ClientResponseError, OperationFailedError) as exc:
                 self._unset_optimistic_data(OptimisticAttribute.HVAC_MODE)
                 _LOGGER.error("Failed to start air conditioning: %s", exc)
+        elif self._supports_camping() and self._is_camping_active():
+            # Camping keeps the AC running; a plain _stop_air_conditioning would not
+            # end it, so call _stop_camping instead.
+            self._set_optimistic_data(OptimisticAttribute.PRESET_MODE, PRESET_NONE)
+            _LOGGER.info("Camping mode active, stopping camping mode.")
+            try:
+                await self._stop_camping()
+            except (ClientResponseError, OperationFailedError) as exc:
+                self._unset_optimistic_data(OptimisticAttribute.HVAC_MODE)
+                self._unset_optimistic_data(OptimisticAttribute.PRESET_MODE)
+                _LOGGER.error("Failed to stop camping mode: %s", exc)
         else:
             _LOGGER.info("Stopping Air conditioning.")
             try:
                 await self._stop_air_conditioning()
             except (ClientResponseError, OperationFailedError) as exc:
+                self._unset_optimistic_data(OptimisticAttribute.HVAC_MODE)
                 _LOGGER.error("Failed to stop air conditioning: %s", exc)
         _LOGGER.info("HVAC mode set to %s.", hvac_mode)
 
@@ -327,6 +397,37 @@ class MySkodaClimate(MySkodaClimateEntity):
 
     async def async_turn_off(self):  # noqa: D102
         await self.async_set_hvac_mode(HVACMode.OFF)
+
+    @Throttle(timedelta(seconds=API_COOLDOWN_IN_SECONDS))
+    async def async_set_preset_mode(self, preset_mode: str) -> None:  # noqa: D102
+        if not self._supports_camping():
+            return
+
+        if preset_mode == PRESET_CAMPING:
+            if not (ac := self._air_conditioning()):
+                _LOGGER.debug(
+                    "Cannot start camping mode: air conditioning unavailable."
+                )
+                return
+            if not (target_temperature := ac.target_temperature):
+                _LOGGER.debug("Cannot start camping mode: no target temperature set.")
+                return
+            self._set_optimistic_data(OptimisticAttribute.PRESET_MODE, preset_mode)
+            _LOGGER.info("Starting camping mode.")
+            try:
+                await self._start_camping(target_temperature.temperature_value)
+            except (ClientResponseError, OperationFailedError) as exc:
+                self._unset_optimistic_data(OptimisticAttribute.PRESET_MODE)
+                _LOGGER.error("Failed to start camping mode: %s", exc)
+        elif self._is_camping_active():
+            self._set_optimistic_data(OptimisticAttribute.PRESET_MODE, preset_mode)
+            _LOGGER.info("Stopping camping mode.")
+            try:
+                await self._stop_camping()
+            except (ClientResponseError, OperationFailedError) as exc:
+                self._unset_optimistic_data(OptimisticAttribute.PRESET_MODE)
+                _LOGGER.error("Failed to stop camping mode: %s", exc)
+        _LOGGER.info("Preset mode set to %s.", preset_mode)
 
     @Throttle(timedelta(seconds=API_COOLDOWN_IN_SECONDS))
     async def async_set_temperature(self, **kwargs):  # noqa: D102

--- a/custom_components/myskoda/climate.py
+++ b/custom_components/myskoda/climate.py
@@ -404,29 +404,35 @@ class MySkodaClimate(MySkodaClimateEntity):
             return
 
         if preset_mode == PRESET_CAMPING:
-            if not (ac := self._air_conditioning()):
-                _LOGGER.debug(
-                    "Cannot start camping mode: air conditioning unavailable."
+            if not (ac := self._air_conditioning()) or not (
+                target_temperature := ac.target_temperature
+            ):
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="camping_no_target_temperature",
                 )
-                return
-            if not (target_temperature := ac.target_temperature):
-                _LOGGER.debug("Cannot start camping mode: no target temperature set.")
-                return
             self._set_optimistic_data(OptimisticAttribute.PRESET_MODE, preset_mode)
+            self._set_optimistic_data(OptimisticAttribute.HVAC_MODE, HVACMode.HEAT_COOL)
             _LOGGER.info("Starting camping mode.")
             try:
                 await self._start_camping(target_temperature.temperature_value)
             except (ClientResponseError, OperationFailedError) as exc:
                 self._unset_optimistic_data(OptimisticAttribute.PRESET_MODE)
+                self._unset_optimistic_data(OptimisticAttribute.HVAC_MODE)
                 _LOGGER.error("Failed to start camping mode: %s", exc)
-        elif self._is_camping_active():
-            self._set_optimistic_data(OptimisticAttribute.PRESET_MODE, preset_mode)
-            _LOGGER.info("Stopping camping mode.")
-            try:
-                await self._stop_camping()
-            except (ClientResponseError, OperationFailedError) as exc:
-                self._unset_optimistic_data(OptimisticAttribute.PRESET_MODE)
-                _LOGGER.error("Failed to stop camping mode: %s", exc)
+        elif preset_mode == PRESET_NONE:
+            if self._is_camping_active():
+                self._set_optimistic_data(OptimisticAttribute.PRESET_MODE, preset_mode)
+                self._set_optimistic_data(OptimisticAttribute.HVAC_MODE, HVACMode.OFF)
+                _LOGGER.info("Stopping camping mode.")
+                try:
+                    await self._stop_camping()
+                except (ClientResponseError, OperationFailedError) as exc:
+                    self._unset_optimistic_data(OptimisticAttribute.PRESET_MODE)
+                    self._unset_optimistic_data(OptimisticAttribute.HVAC_MODE)
+                    _LOGGER.error("Failed to stop camping mode: %s", exc)
+        else:
+            _LOGGER.warning("Unsupported preset mode: %s", preset_mode)
         _LOGGER.info("Preset mode set to %s.", preset_mode)
 
     @Throttle(timedelta(seconds=API_COOLDOWN_IN_SECONDS))

--- a/custom_components/myskoda/manifest.json
+++ b/custom_components/myskoda/manifest.json
@@ -17,7 +17,7 @@
     "myskoda"
   ],
   "requirements": [
-    "myskoda==2.14.0"
+    "myskoda==2.15.0"
   ],
   "version": "1.34.1"
 }

--- a/custom_components/myskoda/sensor.py
+++ b/custom_components/myskoda/sensor.py
@@ -195,6 +195,7 @@ class CampingModeEndsAt(MySkodaSensor):
         key="camping_mode_ends_at",
         translation_key="camping_mode_ends_at",
         device_class=SensorDeviceClass.TIMESTAMP,
+        icon="mdi:tent",
     )
 
     @property

--- a/custom_components/myskoda/sensor.py
+++ b/custom_components/myskoda/sensor.py
@@ -48,6 +48,7 @@ async def async_setup_entry(
         available_entities=[
             AddBlueRange,
             BatteryPercentage,
+            CampingModeEndsAt,
             ChargeType,
             ChargingPower,
             ChargingRate,
@@ -185,6 +186,25 @@ class ServiceEvent(MySkodaSensor):
         attributes["history"] = filtered[1:]
 
         return attributes
+
+
+class CampingModeEndsAt(MySkodaSensor):
+    """Report when camping mode will automatically end."""
+
+    entity_description = SensorEntityDescription(
+        key="camping_mode_ends_at",
+        translation_key="camping_mode_ends_at",
+        device_class=SensorDeviceClass.TIMESTAMP,
+    )
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return when camping mode ends, if active."""
+        if (ac := self.vehicle.air_conditioning) and ac.camping_mode is not None:
+            return ac.camping_mode.ends_at
+
+    def required_capabilities(self) -> list[CapabilityId]:
+        return [CapabilityId.CAMPING_MODE]
 
 
 class SoftwareVersion(MySkodaSensor):

--- a/custom_components/myskoda/translations/en.json
+++ b/custom_components/myskoda/translations/en.json
@@ -109,7 +109,15 @@
         },
         "climate": {
             "climate": {
-                "name": "Air Conditioning"
+                "name": "Air Conditioning",
+                "state_attributes": {
+                    "preset_mode": {
+                        "state": {
+                            "none": "Normal",
+                            "camping": "Camping"
+                        }
+                    }
+                }
             },
             "auxiliary_heater": {
                 "name": "Auxiliary Heater"
@@ -205,6 +213,9 @@
             },
             "service_event": {
                 "name": "Last Service Event"
+            },
+            "camping_mode_ends_at": {
+                "name": "Camping Mode Ends"
             },
             "software_version": {
                 "name": "Software Version"

--- a/custom_components/myskoda/translations/en.json
+++ b/custom_components/myskoda/translations/en.json
@@ -371,6 +371,9 @@
     "exceptions": {
         "readonly_mode": {
             "message": "Read-only mode enabled. Command operations are disabled."
+        },
+        "camping_no_target_temperature": {
+            "message": "Cannot start camping mode without a target temperature."
         }
     }
 }

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -7,6 +7,7 @@
 | `adblue_range`                                        | AdBlue Range                               | km         | STATE, FUEL_STATUS                | Not shown for electric vehicles            |
 | `aux_estimated_time_left_to_reach_target_temperature` | Heater Time to reach target temperature    | min        | AUXILIARY_HEATING                 |                                            |
 | `battery_percentage`                                  | Battery Percentage                         | %          | CHARGING                          | Dynamic icon tracks charge level           |
+| `camping_mode_ends_at`                                | Camping Mode Ends                          | timestamp  | CAMPING_MODE                      | When camping mode auto-ends                |
 | `car_captured`                                        | Last Updated                               | timestamp  | STATE                             | See [Last Updated sensor](#last-updated-sensor) |
 | `charge_type`                                         | Charge Type                                |            | CHARGING                          | AC, DC                                     |
 | `charging_power`                                      | Charging Power                             | kW         | CHARGING, EXTENDED_CHARGING_SETTINGS |                                         |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.13.2,<3.15"
-dependencies = ["homeassistant>=2025.3.2", "myskoda>=2.14.0,<2.15"]
+dependencies = ["homeassistant>=2025.3.2", "myskoda>=2.15.0,<2.16"]
 
 [dependency-groups]
 dev = ["homeassistant-stubs>=2025.3.2", "ruff>=0.15.20,<0.16", "pyright>=1.1.411,<1.2"]

--- a/uv.lock
+++ b/uv.lock
@@ -1724,7 +1724,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2025.3.2" },
-    { name = "myskoda", specifier = ">=2.14.0,<2.15" },
+    { name = "myskoda", specifier = ">=2.15.0,<2.16" },
 ]
 
 [package.metadata.requires-dev]
@@ -2079,7 +2079,7 @@ wheels = [
 
 [[package]]
 name = "myskoda"
-version = "2.14.0"
+version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -2092,9 +2092,9 @@ dependencies = [
     { name = "pyjwt", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14.2'" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/d9/8503375754294620303074ef08ac390821c0741282fe804d487de1f3a1a0/myskoda-2.14.0.tar.gz", hash = "sha256:b58dd58e27f7e2d9ff130a67cf126c1566ec28e752aa04668085e6012f39f5a9", size = 415704, upload-time = "2026-06-29T12:16:11.899Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/01/b35709d7da4aea7f121ce2d42d879d68984db62e1e33a3b5d970319fc921/myskoda-2.15.0.tar.gz", hash = "sha256:d56c2a47bad8ce681a3f921409a20fa9539dae2caea1029e44a9daf59141c214", size = 419404, upload-time = "2026-07-11T19:47:19.7Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/41/4444705ccf0e354400ebb25017380ba4e8fc70ea89abc080ce3b7d05b963/myskoda-2.14.0-py3-none-any.whl", hash = "sha256:9a484d395df4b7fefe6c121a96d23210a72211fb646aa651ea8b1ba291e7a5ff", size = 90945, upload-time = "2026-06-29T12:16:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/26/8ba3f1943d1f6b409008b9338ab76f39129888daa7d550d91818e7ebdbab/myskoda-2.15.0-py3-none-any.whl", hash = "sha256:818f04ad6577d2646e68c48e56c70e8978a08358735d811c52eb8164e5eaa108", size = 93054, upload-time = "2026-07-11T19:47:18.695Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This exposes camping mode as a "camping" preset on the air-conditioning climate entity, gated on the CAMPING_MODE capability.

testing done:
- with HVAC off; set preset=camping; start_camping with the current AC target temperature called and confirmed by Myskoda app right away
- with HVAC on and preset=camping; selecting preset=none calls stop_camping and turns everything off
- with HVAC on and preset=camping; turning off AC, conditionally calls stop_camping (as calling stop_ac would not work)
- regular AC on/off still works

It also adds a timestamp sensor for campingMode.endsAt, so the remaining time is visible in HA. I feel like it partially duplicates the "AC Time to reach target temperature" entity. But putting both AC-related time sensors into this entity, would require renaming.

Depends on https://github.com/skodaconnect/myskoda/releases/tag/v2.15.0, so bumped pyproject.toml / uv.lock accordingly.
